### PR TITLE
Harvest community tasting notes from CellarTracker RSS (#26)

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -11,6 +11,9 @@ GOOGLE_CALENDAR_ICS_URL="op://<vault>/<item>/GOOGLE_CALENDAR_ICS_URL"
 # Claude Code OAuth token for tasting note generation (1Password secret reference)
 CLAUDE_CODE_OAUTH_TOKEN="op://<vault>/<item>/CLAUDE_CODE_OAUTH_TOKEN"
 
+# CellarTracker community notes RSS feed URL (1Password secret reference)
+CT_COMMUNITY_NOTES_RSS="op://<vault>/<item>/RSS"
+
 # Healthchecks.io ping key (1Password secret reference)
 HEALTHCHECK_PING_KEY="op://<vault>/<item>/ping_key"
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,11 +17,12 @@ FETCH (scripted, parallel)
   ├── CellarTracker notes      → data/notes.tsv
   ├── CellarTracker food tags  → data/foodtags.tsv
   ├── CellarTracker consumed   → data/consumed.tsv → data/consumed.json
+  ├── CellarTracker community notes (RSS) → data/community_notes.json (cumulative)
   └── Google Calendar menu     → data/menu.ics → data/menu.json
 
 GENERATE PLAN (scripted — rules-based) → data/plan.json (staging)
 
-GENERATE NOTES (LLM — Claude Code CLI) → data/plan.json (augmented with CT notes)
+GENERATE NOTES (LLM — Claude Code CLI) → data/plan.json (augmented with CT notes + community notes)
 
 COMPARE & PAIR (scripted)
   ├── inventory + plan → data/report.json
@@ -52,6 +53,7 @@ scripts/
   wine_keywords.py            — Single source of truth for food keywords and pairing rules
   parse_inventory.py          — inventory.tsv → inventory.json
   parse_consumed.py           — consumed.tsv → consumed.json (consumption history)
+  fetch_community_notes.py    — RSS feed → community_notes.json (cumulative cache, deduped by iNote)
   parse_menu.py               — menu.ics → menu.json (Google Calendar .ics feed)
   compare.py                  — inventory.json + plan.json → report.json
   pairing.py                  — menu.json + plan.json + inventory.json → pairing_suggestions.json
@@ -64,6 +66,7 @@ data/                         — Staging area + generated artifacts (gitignored
   plan.json                   — Staged plan (copied to site/ after notes generated)
   plan_previous.json          — Backup of previous live plan (for changelog diff)
   consumed.json               — Parsed consumption history (generated from consumed.tsv)
+  community_notes.json        — Cumulative community tasting notes cache (from RSS, keyed by iWine)
 conftest.py                   — pytest config: adds scripts/ to sys.path
 pyrightconfig.json            — Pyright type checking config
 pipeline.sh                   — Shared pipeline logic (sourced by fetch.sh and fetch_docker.sh)
@@ -155,7 +158,7 @@ Implemented in `scripts/generate_plan.py`:
 - `Table=Notes` — user's tasting notes (augments Claude-generated notes)
 - `Table=FoodTags` — user's food pairing tags (augments pairing suggestions)
 - `Table=Consumed` — consumption history (non-fatal; continues without if fetch fails)
-- Community tasting notes are NOT available via the export API
+- `rssnote.asp` RSS feed — community tasting notes for wines in your cellar (up to 200 items per fetch, cumulative cache at `data/community_notes.json`). Requires `CK` token in 1Password. Non-fatal; continues without if unavailable.
 
 ## Google Calendar Integration
 
@@ -186,4 +189,4 @@ Implemented in `scripts/generate_plan.py`:
 - Plan is regenerated from scratch every pipeline run — no manual editing of `plan.json`
 - Plan staged to `data/plan.json`, only published to `site/` when complete with notes
 - Shared utilities in `scripts/wine_utils.py` — do not duplicate `urgency_score`, `normalize`, `TYPE_TO_BADGE`, or `CURRENT_YEAR` in individual scripts
-- Composite scoring in `scripts/scoring.py` — `composite_score()` combines window position (50%), seasonal fit (25%), diversity (15%), CT quality (10%). Lower score = schedule sooner. Plan labels show best available critic score (WA → WS → BH → AG → JR → JS → JG → CT). Also owns `seasonal_score()` and red-subtype helpers (moved from `generate_plan.py` to avoid circular imports)
+- Composite scoring in `scripts/scoring.py` — `composite_score()` combines window position (50%), seasonal fit (25%), diversity (10%), CT quality (10%), community signals (5%). Community signals use RSS note data: recent score drift, note velocity, and text-based window drift detection. Lower score = schedule sooner. Plan labels show best available critic score (WA → WS → BH → AG → JR → JS → JG → CT). Also owns `seasonal_score()` and red-subtype helpers (moved from `generate_plan.py` to avoid circular imports)

--- a/pipeline.sh
+++ b/pipeline.sh
@@ -52,6 +52,7 @@ CT_PASSWORD=$(op read "$PASSWORD") || { log "ERROR: Failed to resolve CellarTrac
 GOOGLE_CALENDAR_ICS_URL=$(op read "$GOOGLE_CALENDAR_ICS_URL") || { log "ERROR: Failed to resolve Google Calendar URL from 1Password"; exit 1; }
 export CLAUDE_CODE_OAUTH_TOKEN
 CLAUDE_CODE_OAUTH_TOKEN=$(op read "$CLAUDE_CODE_OAUTH_TOKEN") || { log "WARNING: Failed to resolve Claude OAuth token from 1Password"; }
+CT_COMMUNITY_NOTES_RSS=$(op read "$CT_COMMUNITY_NOTES_RSS") || { log "WARNING: Failed to resolve community notes RSS URL from 1Password — continuing without community notes"; }
 
 CT_BASE="https://www.cellartracker.com/xlquery.asp?User=${CT_USERNAME}&Password=${CT_PASSWORD}&Format=tab"
 
@@ -99,6 +100,14 @@ if [[ -n "${PID_CONSUMED_PARSE:-}" ]]; then
   wait "$PID_CONSUMED_PARSE" || { log "WARNING: Consumed parse failed — continuing without consumed data"; }
 fi
 
+# --- FETCH COMMUNITY NOTES (RSS) ---
+if [[ -n "${CT_COMMUNITY_NOTES_RSS:-}" ]]; then
+  log "==> Fetching community tasting notes (RSS)..."
+  CT_COMMUNITY_NOTES_RSS="${CT_COMMUNITY_NOTES_RSS}" python3 scripts/fetch_community_notes.py data/community_notes.json || log "WARNING: Community notes fetch failed — continuing without community notes"
+else
+  log "    Skipping community notes — CT_COMMUNITY_NOTES_RSS not configured"
+fi
+
 # --- GENERATE PLAN to staging (scripted — rules-based) ---
 # Build new plan in data/ first, only publish to site/ when complete with notes
 log "==> Generating plan..."
@@ -107,7 +116,7 @@ python3 scripts/generate_plan.py data/inventory.json data/plan.json || { log "ER
 # --- GENERATE NOTES (LLM — Claude Code CLI, augmented with CT notes) ---
 if command -v claude &> /dev/null; then
   log "==> Generating tasting notes (Claude)..."
-  python3 scripts/generate_notes.py data/plan.json data/notes.tsv data/foodtags.tsv || log "WARNING: Note generation failed — plan will have empty notes"
+  python3 scripts/generate_notes.py data/plan.json data/notes.tsv data/foodtags.tsv data/community_notes.json || log "WARNING: Note generation failed — plan will have empty notes"
 else
   log "    Skipping note generation — claude CLI not available"
 fi

--- a/scripts/fetch_community_notes.py
+++ b/scripts/fetch_community_notes.py
@@ -175,11 +175,18 @@ def fetch_community_notes(rss_url: str, cache_path: Path) -> None:
     cache = load_cache(cache_path)
     cache, added = merge_notes(cache, new_notes)
 
-    # Write
+    # Write atomically (tmp + rename) to protect cumulative cache from partial writes
     cache_path.parent.mkdir(parents=True, exist_ok=True)
-    cache_path.write_text(
-        json.dumps(cache, indent=2, ensure_ascii=False), encoding="utf-8"
-    )
+    tmp_path = cache_path.with_suffix(".tmp")
+    try:
+        tmp_path.write_text(
+            json.dumps(cache, indent=2, ensure_ascii=False), encoding="utf-8"
+        )
+        tmp_path.replace(cache_path)
+    except OSError as e:
+        print(f"ERROR: Failed to write community notes cache: {e}", file=sys.stderr)
+        tmp_path.unlink(missing_ok=True)
+        sys.exit(1)
 
     total = sum(len(v) for v in cache.values())
     wines = len(cache)

--- a/scripts/fetch_community_notes.py
+++ b/scripts/fetch_community_notes.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""Fetch community tasting notes from CellarTracker RSS feed.
+
+Polls rssnote.asp using a personal CK token, parses each <item> into
+structured note records, and appends to a cumulative JSON cache keyed
+by iWine. Never overwrites — only adds new notes (deduped by iNote).
+
+Usage: fetch_community_notes.py <rss_url> [community_notes.json]
+"""
+
+import json
+import re
+import sys
+import urllib.request
+import xml.etree.ElementTree as ET
+from datetime import datetime
+from pathlib import Path
+
+
+def sanitize_bbcode(text: str) -> str:
+    """Strip BBCode markup (e.g., [url=...]...[/url])."""
+    text = re.sub(r"\[url=[^\]]*\](.*?)\[/url\]", r"\1", text)
+    text = re.sub(r"\[/?[a-zA-Z]+[^\]]*\]", "", text)
+    return text.strip()
+
+
+def parse_rss_item(item: ET.Element) -> dict | None:
+    """Parse a single RSS <item> into a note record."""
+    link = item.findtext("link", "")
+    guid = item.findtext("guid", "")
+    title = item.findtext("title", "").strip()
+    pub_date = item.findtext("pubDate", "").strip()
+    description = item.findtext("description", "").strip()
+
+    # Extract iWine from link: .../notes.asp?iWine=12345...
+    iwine_match = re.search(r"iWine=(\d+)", link or guid)
+    if not iwine_match:
+        return None
+    iwine = iwine_match.group(1)
+
+    # Extract iNote from link or guid: ...#iNote12345 or iNote=12345
+    inote_match = re.search(r"iNote[=]?(\d+)", link or guid)
+    inote = inote_match.group(1) if inote_match else ""
+
+    if not inote:
+        return None
+
+    # Parse description for author, score, body, tasting_date
+    author = ""
+    author_match = re.match(r"^Tasted by (.+?)\.", description)
+    if author_match:
+        author = author_match.group(1).strip()
+
+    score = None
+    score_match = re.search(r"\((\d+)\s*pts?\.\)", description)
+    if score_match:
+        score = int(score_match.group(1))
+
+    tasting_date = ""
+    date_match = re.search(r"Tasted\s+(\d+/\d+/\d+)", description)
+    if date_match:
+        tasting_date = date_match.group(1)
+
+    # Extract body: everything after the metadata line
+    # Typical format: "Tasted by author. (92 pts.) Tasted 4/11/2026\n\nActual note body"
+    body = description
+    # Remove the first line (metadata)
+    lines = description.split("\n", 1)
+    if len(lines) > 1:
+        body = lines[1].strip()
+    else:
+        # Try removing the metadata prefix
+        body = re.sub(
+            r"^Tasted by .+?\.\s*(\(\d+\s*pts?\.\))?\s*(Tasted\s+\d+/\d+/\d+)?\s*",
+            "",
+            body,
+        ).strip()
+
+    body = sanitize_bbcode(body)
+
+    return {
+        "iWine": iwine,
+        "iNote": inote,
+        "title": title,
+        "pubDate": pub_date,
+        "author": author,
+        "score": score,
+        "body": body if body else None,
+        "tasting_date": tasting_date if tasting_date else None,
+    }
+
+
+def parse_rss(xml_text: str) -> list[dict]:
+    """Parse RSS XML into a list of note records."""
+    try:
+        root = ET.fromstring(xml_text)
+    except ET.ParseError as e:
+        print(f"WARNING: RSS XML parse error: {e}", file=sys.stderr)
+        return []
+
+    items = root.findall(".//item")
+    notes = []
+    for item in items:
+        record = parse_rss_item(item)
+        if record:
+            notes.append(record)
+    return notes
+
+
+def load_cache(cache_path: Path) -> dict[str, list[dict]]:
+    """Load existing cumulative cache (keyed by iWine)."""
+    if cache_path.exists() and cache_path.stat().st_size > 0:
+        try:
+            return json.loads(cache_path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError) as e:
+            print(f"WARNING: Could not load cache: {e}", file=sys.stderr)
+    return {}
+
+
+def merge_notes(
+    cache: dict[str, list[dict]], new_notes: list[dict]
+) -> tuple[dict[str, list[dict]], int]:
+    """Merge new notes into cache, deduplicating by iNote. Returns (cache, added_count)."""
+    # Build a set of existing iNote IDs for fast lookup
+    existing_inotes: set[str] = set()
+    for notes_list in cache.values():
+        for note in notes_list:
+            existing_inotes.add(note["iNote"])
+
+    added = 0
+    for note in new_notes:
+        if note["iNote"] in existing_inotes:
+            continue
+        iwine = note["iWine"]
+        cache.setdefault(iwine, []).append(note)
+        existing_inotes.add(note["iNote"])
+        added += 1
+
+    # Sort each wine's notes by tasting_date descending (most recent first)
+    def _parse_date(n: dict) -> datetime:
+        td = n.get("tasting_date")
+        if td:
+            try:
+                return datetime.strptime(td, "%m/%d/%Y")
+            except ValueError:
+                pass
+        return datetime.min
+
+    for iwine in cache:
+        cache[iwine].sort(key=_parse_date, reverse=True)
+
+    return cache, added
+
+
+def fetch_community_notes(rss_url: str, cache_path: Path) -> None:
+    """Fetch RSS feed, parse, merge into cumulative cache."""
+    # Fetch RSS
+    try:
+        req = urllib.request.Request(
+            rss_url, headers={"User-Agent": "The-Sommelier/1.0"}
+        )
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            xml_text = resp.read().decode("utf-8", errors="replace")
+    except Exception as e:
+        print(f"ERROR: RSS fetch failed: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    # Parse
+    new_notes = parse_rss(xml_text)
+    if not new_notes:
+        print("No notes found in RSS feed.")
+        return
+
+    # Merge
+    cache = load_cache(cache_path)
+    cache, added = merge_notes(cache, new_notes)
+
+    # Write
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    cache_path.write_text(
+        json.dumps(cache, indent=2, ensure_ascii=False), encoding="utf-8"
+    )
+
+    total = sum(len(v) for v in cache.values())
+    wines = len(cache)
+    print(f"Community notes: {added} new, {total} total across {wines} wines")
+
+
+if __name__ == "__main__":
+    import os
+
+    url = os.environ.get("CT_COMMUNITY_NOTES_RSS", "")
+    if not url:
+        print(
+            "ERROR: CT_COMMUNITY_NOTES_RSS environment variable not set",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    cache = (
+        Path(sys.argv[1]) if len(sys.argv) > 1 else Path("data/community_notes.json")
+    )
+    fetch_community_notes(url, cache)

--- a/scripts/generate_notes.py
+++ b/scripts/generate_notes.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python3
 """Generate tasting notes for plan entries using Claude Code CLI.
 
-Reads plan.json and optionally CellarTracker notes/food tags to generate
-contextual tasting notes. Claude augments any existing CT tasting notes
-and food pairing data.
+Reads plan.json and optionally CellarTracker notes/food tags and community
+notes to generate contextual tasting notes. Claude augments any existing
+CT tasting notes, community tasting notes, and food pairing data.
 
 Requires CLAUDE_CODE_OAUTH_TOKEN in the environment.
 
-Usage: generate_notes.py <plan.json> [notes.tsv] [foodtags.tsv]
+Usage: generate_notes.py <plan.json> [notes.tsv] [foodtags.tsv] [community_notes.json]
 """
 
 import csv
@@ -87,13 +87,24 @@ def find_iwine(vintage: str, name: str, inv_index: dict[str, str]) -> str:
     return ""
 
 
+def load_community_notes(path: str | None) -> dict[str, list[dict]]:
+    """Load community notes JSON cache, indexed by iWine."""
+    if not path:
+        return {}
+    from fetch_community_notes import load_cache
+
+    return load_cache(Path(path))
+
+
 def build_prompt(
     entries: list[dict],
     ct_notes: dict[str, list[str]],
     ct_foodtags: dict[str, list[str]],
     inv_index: dict[str, str],
+    community_notes: dict[str, list[dict]] | None = None,
 ) -> str:
     """Build a prompt for Claude to generate notes, augmented with CT data."""
+    community_notes = community_notes or {}
     lines = []
     for e in entries:
         urgent = "URGENT — past peak or expiring" if e.get("urgent") else ""
@@ -118,6 +129,19 @@ def build_prompt(
             tags = ct_foodtags.get(iwine, [])
             if tags:
                 line += f"\n  Food pairings (from CT): {', '.join(tags[:5])}"
+            # Include recent community tasting notes
+            cn = community_notes.get(iwine, [])
+            if cn:
+                quotes = []
+                for n in cn[:3]:
+                    score_str = f" ({n['score']} pts)" if n.get("score") else ""
+                    body = (n.get("body") or "")[:150]
+                    if body:
+                        quotes.append(
+                            f'"{body}"{score_str} — {n.get("author", "anon")}'
+                        )
+                if quotes:
+                    line += "\n  Community notes: " + " | ".join(quotes)
 
         lines.append(line)
 
@@ -125,6 +149,7 @@ def build_prompt(
     return f"""Generate a one-sentence tasting note for each wine below. The note should:
 - Be 1-2 sentences max, conversational tone
 - If a CellarTracker note is provided, build on it — don't repeat it verbatim but reference the user's experience
+- If community notes are provided, ground your note in what real tasters are saying — reference consensus or standout observations
 - If food pairings from CT are provided, incorporate them as suggestions
 - For urgent/past-peak wines: acknowledge the wine may be declining, suggest decanting or having a backup
 - For evolution wines: mention comparing with previous/future vintages
@@ -177,6 +202,7 @@ def generate_notes(
     plan_path: str,
     notes_path: str | None = None,
     foodtags_path: str | None = None,
+    community_notes_path: str | None = None,
 ) -> None:
     """Generate notes for plan entries with empty notes."""
     plan_data = json.loads(Path(plan_path).read_text())
@@ -185,6 +211,7 @@ def generate_notes(
     # Load CellarTracker data if available
     ct_notes = parse_ct_notes(notes_path) if notes_path else {}
     ct_foodtags = parse_ct_foodtags(foodtags_path) if foodtags_path else {}
+    community_notes = load_community_notes(community_notes_path)
     inv_index = load_inventory_index(plan_data)
 
     if ct_notes:
@@ -192,6 +219,11 @@ def generate_notes(
     if ct_foodtags:
         print(
             f"  Loaded {sum(len(v) for v in ct_foodtags.values())} CellarTracker food tags"
+        )
+    if community_notes:
+        total_cn = sum(len(v) for v in community_notes.values())
+        print(
+            f"  Loaded {total_cn} community notes across {len(community_notes)} wines"
         )
 
     # Find entries that need notes
@@ -206,7 +238,7 @@ def generate_notes(
     notes_generated = 0
     for i in range(0, len(needs_notes), BATCH_SIZE):
         batch = needs_notes[i : i + BATCH_SIZE]
-        prompt = build_prompt(batch, ct_notes, ct_foodtags, inv_index)
+        prompt = build_prompt(batch, ct_notes, ct_foodtags, inv_index, community_notes)
 
         print(f"  Batch {i // BATCH_SIZE + 1}: {len(batch)} wines...")
         response = call_claude(prompt)
@@ -232,7 +264,7 @@ def generate_notes(
 if __name__ == "__main__":
     if len(sys.argv) < 2:
         print(
-            "Usage: generate_notes.py <plan.json> [notes.tsv] [foodtags.tsv]",
+            "Usage: generate_notes.py <plan.json> [notes.tsv] [foodtags.tsv] [community_notes.json]",
             file=sys.stderr,
         )
         sys.exit(1)
@@ -240,4 +272,5 @@ if __name__ == "__main__":
         sys.argv[1],
         sys.argv[2] if len(sys.argv) > 2 else None,
         sys.argv[3] if len(sys.argv) > 3 else None,
+        sys.argv[4] if len(sys.argv) > 4 else None,
     )

--- a/scripts/generate_plan.py
+++ b/scripts/generate_plan.py
@@ -661,8 +661,11 @@ def _load_community_notes() -> dict[str, list[dict]] | None:
     if cn_path.exists() and cn_path.stat().st_size > 0:
         try:
             return json.loads(cn_path.read_text(encoding="utf-8"))
-        except (json.JSONDecodeError, OSError):
-            pass
+        except (json.JSONDecodeError, OSError) as exc:
+            print(
+                f"WARNING: Could not load community notes: {exc}",
+                file=sys.stderr,
+            )
     return None
 
 

--- a/scripts/generate_plan.py
+++ b/scripts/generate_plan.py
@@ -381,6 +381,7 @@ def _pick_best_for_slot(
     placed: list[dict | None] | None = None,
     exclude_keys: set[str] | None = None,
     required_fragment: str | None = None,
+    community_notes: dict[str, list[dict]] | None = None,
 ) -> dict | None:
     """Pick the best available bottle for a given slot using composite scoring."""
     exclude_keys = exclude_keys or set()
@@ -402,7 +403,7 @@ def _pick_best_for_slot(
 
     pool.sort(
         key=lambda w: (
-            composite_score(w, season, week_index, placed or []),
+            composite_score(w, season, week_index, placed or [], community_notes),
             w.get("EndConsume") or 9999,
             w.get("Wine", ""),
         )
@@ -654,12 +655,24 @@ def schedule_evolution_tracks(
             }
 
 
+def _load_community_notes() -> dict[str, list[dict]] | None:
+    """Load community notes cache if available."""
+    cn_path = Path("data/community_notes.json")
+    if cn_path.exists() and cn_path.stat().st_size > 0:
+        try:
+            return json.loads(cn_path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            pass
+    return None
+
+
 def generate_plan(inventory: list[dict]) -> dict:
     """Generate the full 52-week plan from inventory data."""
     today = date.today()
     start = monday_of_week(today)
     week_dates = generate_week_dates(start)
 
+    community_notes = _load_community_notes()
     candidates = build_candidates(inventory)
 
     # Track how many bottles of each wine we've already scheduled
@@ -731,6 +744,7 @@ def generate_plan(inventory: list[dict]) -> dict:
                 max_urgency=1,
                 week_index=i,
                 placed=placed,
+                community_notes=community_notes,
             )
         elif i < 16:
             # Phase B: expiring this/next year
@@ -741,6 +755,7 @@ def generate_plan(inventory: list[dict]) -> dict:
                 max_urgency=2,
                 week_index=i,
                 placed=placed,
+                community_notes=community_notes,
             )
         else:
             # Phase C: composite scoring
@@ -750,6 +765,7 @@ def generate_plan(inventory: list[dict]) -> dict:
                 season,
                 week_index=i,
                 placed=placed,
+                community_notes=community_notes,
             )
 
         if wine is None:
@@ -760,6 +776,7 @@ def generate_plan(inventory: list[dict]) -> dict:
                 season,
                 week_index=i,
                 placed=placed,
+                community_notes=community_notes,
             )
 
         if wine is None:
@@ -790,6 +807,7 @@ def _pick_for_urgent_phase(
     max_urgency: int,
     week_index: int = 0,
     placed: list[dict | None] | None = None,
+    community_notes: dict[str, list[dict]] | None = None,
 ) -> dict | None:
     """Pick the best bottle at or below *max_urgency* tier, sorted by composite score."""
     pool = []
@@ -803,7 +821,7 @@ def _pick_for_urgent_phase(
         return None
     pool.sort(
         key=lambda w: (
-            composite_score(w, season, week_index, placed or []),
+            composite_score(w, season, week_index, placed or [], community_notes),
             w.get("EndConsume") or 9999,
             w.get("Wine", ""),
         )

--- a/scripts/scoring.py
+++ b/scripts/scoring.py
@@ -6,10 +6,14 @@ Symbols exported:
   seasonal_score        — seasonal fit penalty (0=perfect, 1=acceptable, 2=poor)
   seasonal_fit_score    — seasonal fit as a 0–100 float (higher = better fit)
   ct_score_component    — CellarTracker quality score normalized to 0–100
+  community_score       — community signals score from RSS notes (0–100)
   diversity_score       — diversity penalty based on proximity to similar placed wines (0–100)
   diversity_penalty     — linear decay helper for diversity scoring
   composite_score       — weighted combination of all components (lower = schedule sooner)
 """
+
+import re
+from datetime import datetime, timedelta
 
 from wine_utils import CURRENT_YEAR, TYPE_TO_BADGE
 
@@ -158,6 +162,93 @@ def ct_score_component(wine: dict) -> float:
 
 
 # ---------------------------------------------------------------------------
+# Community signals scoring
+# ---------------------------------------------------------------------------
+
+# Regex patterns for window drift detection in community note bodies
+_DRIFT_DRINK_NOW = re.compile(
+    r"past\s+prime|fading|tired|over\s+the\s+hill|declining|drink\s+(it\s+)?now|"
+    r"peaked|losing|falling\s+apart|drying\s+out",
+    re.IGNORECASE,
+)
+_DRIFT_HOLD = re.compile(
+    r"needs?\s+time|closed|young|tight|tannic|too\s+young|years?\s+away|"
+    r"cellaring|not\s+ready",
+    re.IGNORECASE,
+)
+
+
+def community_score(
+    wine: dict, community_notes: dict[str, list[dict]] | None = None
+) -> float:
+    """Score based on community tasting note signals (0–100, higher = schedule sooner).
+
+    Combines three sub-signals:
+    - recent_score_mean: if recent scores diverge from CT avg, nudge accordingly
+    - note_velocity: many recent notes = people are drinking it now
+    - window_drift: text signals about readiness
+
+    Returns 50.0 (neutral) when no community data is available.
+    """
+    if not community_notes:
+        return 50.0
+
+    iwine = str(wine.get("iWine", ""))
+    notes = community_notes.get(iwine, [])
+    if not notes:
+        return 50.0
+
+    score = 50.0  # neutral baseline
+
+    # Sub-signal 1: recent score mean vs CT average
+    recent_scores = [n["score"] for n in notes[:10] if n.get("score") is not None]
+    if recent_scores:
+        ct = wine.get("CT") or AVG_CT
+        mean_recent = sum(recent_scores) / len(recent_scores)
+        diff = mean_recent - ct
+        # A 4+ point drop → bump urgency (might be disappointing)
+        # A 4+ point rise → quality is better than expected
+        if diff <= -4:
+            score += 10.0  # disappointing → drink sooner to clear
+        elif diff >= 4:
+            score += 5.0  # better than expected → slight bump
+
+    # Sub-signal 2: note velocity (notes in last 30 days)
+    cutoff = datetime.now().date() - timedelta(days=30)
+    recent_count = 0
+    for n in notes:
+        td_str = n.get("tasting_date")
+        if td_str:
+            try:
+                td = datetime.strptime(td_str, "%m/%d/%Y").date()
+                if td >= cutoff:
+                    recent_count += 1
+            except ValueError:
+                pass
+    if recent_count >= 5:
+        score += 10.0  # high velocity → people are drinking these now
+    elif recent_count >= 2:
+        score += 5.0
+
+    # Sub-signal 3: window drift from note text
+    drink_now_hits = 0
+    hold_hits = 0
+    for n in notes[:10]:
+        body = n.get("body") or ""
+        if _DRIFT_DRINK_NOW.search(body):
+            drink_now_hits += 1
+        if _DRIFT_HOLD.search(body):
+            hold_hits += 1
+
+    if drink_now_hits > hold_hits:
+        score += 10.0  # community says drink now
+    elif hold_hits > drink_now_hits:
+        score -= 10.0  # community says hold
+
+    return max(0.0, min(100.0, score))
+
+
+# ---------------------------------------------------------------------------
 # Diversity scoring
 # ---------------------------------------------------------------------------
 
@@ -213,9 +304,10 @@ def diversity_score(wine: dict, week_index: int, placed: list[dict | None]) -> f
 
 W_WINDOW = 0.50
 W_SEASON = 0.25
-W_DIVERSITY = 0.15
+W_DIVERSITY = 0.10
 W_CT = 0.10
-# Weights must sum to 1.0: 0.50 + 0.25 + 0.15 + 0.10 = 1.00
+W_COMMUNITY = 0.05
+# Weights must sum to 1.0: 0.50 + 0.25 + 0.10 + 0.10 + 0.05 = 1.00
 
 
 def composite_score(
@@ -223,6 +315,7 @@ def composite_score(
     season: str,
     week_index: int,
     placed: list[dict | None],
+    community_notes: dict[str, list[dict]] | None = None,
 ) -> float:
     """Weighted composite of all scoring components. Lower = schedule sooner.
 
@@ -234,8 +327,13 @@ def composite_score(
     seasonal = seasonal_fit_score(wine, season)
     diversity = diversity_score(wine, week_index, placed)
     ct = ct_score_component(wine)
+    comm = community_score(wine, community_notes)
 
     desirability = (
-        W_WINDOW * window + W_SEASON * seasonal + W_DIVERSITY * diversity + W_CT * ct
+        W_WINDOW * window
+        + W_SEASON * seasonal
+        + W_DIVERSITY * diversity
+        + W_CT * ct
+        + W_COMMUNITY * comm
     )
     return 100.0 - desirability

--- a/tests/test_fetch_community_notes.py
+++ b/tests/test_fetch_community_notes.py
@@ -1,0 +1,267 @@
+"""Tests for fetch_community_notes.py — RSS parsing, dedup, cumulative cache."""
+
+import json
+
+
+from fetch_community_notes import (
+    load_cache,
+    merge_notes,
+    parse_rss,
+    parse_rss_item,
+    sanitize_bbcode,
+)
+
+# ---------------------------------------------------------------------------
+# Sample RSS XML
+# ---------------------------------------------------------------------------
+
+SAMPLE_RSS = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+<channel>
+<title>CellarTracker Community Notes</title>
+<item>
+  <title>2024 Drouhin Oregon Roserock Pinot Noir</title>
+  <link>https://www.cellartracker.com/notes.asp?iWine=5522345#iNote12483504</link>
+  <guid>https://www.cellartracker.com/notes.asp?iWine=5522345#iNote12483504</guid>
+  <pubDate>Thu, 16 Apr 2026 00:00:00 PST</pubDate>
+  <description>Tasted by nonodannecy. (92 pts.) Tasted 4/11/2026
+Beautiful bright ruby. Cherry and raspberry with earthy undertones.</description>
+</item>
+<item>
+  <title>2018 Domaine Drouhin Oregon Pinot Noir Laurène</title>
+  <link>https://www.cellartracker.com/notes.asp?iWine=3344556#iNote12483505</link>
+  <guid>https://www.cellartracker.com/notes.asp?iWine=3344556#iNote12483505</guid>
+  <pubDate>Wed, 15 Apr 2026 00:00:00 PST</pubDate>
+  <description>Tasted by winecritic42. Tasted 4/10/2026
+Silky and refined, showing great depth.</description>
+</item>
+<item>
+  <title>2020 Adamant Cellars Syrah Artisan</title>
+  <link>https://www.cellartracker.com/notes.asp?iWine=7788990#iNote12483506</link>
+  <guid>https://www.cellartracker.com/notes.asp?iWine=7788990#iNote12483506</guid>
+  <pubDate>Tue, 14 Apr 2026 00:00:00 PST</pubDate>
+  <description>Tasted by reviewer123. (88 pts.) Tasted 4/9/2026
+Dark fruit, pepper, past prime now. Drink it now before it fades.</description>
+</item>
+</channel>
+</rss>"""
+
+
+# ---------------------------------------------------------------------------
+# TestSanitizeBBCode
+# ---------------------------------------------------------------------------
+
+
+class TestSanitizeBBCode:
+    def test_strips_url_bbcode(self):
+        assert (
+            sanitize_bbcode("[url=http://example.com]click here[/url]") == "click here"
+        )
+
+    def test_strips_nested_bbcode(self):
+        assert sanitize_bbcode("[b]bold[/b] text") == "bold text"
+
+    def test_no_bbcode_unchanged(self):
+        assert sanitize_bbcode("just plain text") == "just plain text"
+
+    def test_empty_string(self):
+        assert sanitize_bbcode("") == ""
+
+    def test_multiple_url_tags(self):
+        text = "[url=a]one[/url] and [url=b]two[/url]"
+        assert sanitize_bbcode(text) == "one and two"
+
+
+# ---------------------------------------------------------------------------
+# TestParseRssItem
+# ---------------------------------------------------------------------------
+
+
+class TestParseRssItem:
+    def _make_item(self, link, description, title="Wine"):
+        import xml.etree.ElementTree as ET
+
+        item = ET.Element("item")
+        ET.SubElement(item, "title").text = title
+        ET.SubElement(item, "link").text = link
+        ET.SubElement(item, "guid").text = link
+        ET.SubElement(item, "pubDate").text = "Thu, 16 Apr 2026 00:00:00 PST"
+        ET.SubElement(item, "description").text = description
+        return item
+
+    def test_extracts_iwine_and_inote(self):
+        item = self._make_item(
+            "https://ct.com/notes.asp?iWine=123#iNote456",
+            "Tasted by alice. (90 pts.) Tasted 4/1/2026\nGreat wine.",
+        )
+        result = parse_rss_item(item)
+        assert result is not None
+        assert result["iWine"] == "123"
+        assert result["iNote"] == "456"
+
+    def test_extracts_author(self):
+        item = self._make_item(
+            "https://ct.com/notes.asp?iWine=1#iNote2",
+            "Tasted by john_doe. (88 pts.) Tasted 1/1/2026\nNice.",
+        )
+        result = parse_rss_item(item)
+        assert result["author"] == "john_doe"
+
+    def test_extracts_score(self):
+        item = self._make_item(
+            "https://ct.com/notes.asp?iWine=1#iNote2",
+            "Tasted by x. (95 pts.) Tasted 1/1/2026\nGreat.",
+        )
+        result = parse_rss_item(item)
+        assert result["score"] == 95
+
+    def test_missing_score_is_none(self):
+        item = self._make_item(
+            "https://ct.com/notes.asp?iWine=1#iNote2",
+            "Tasted by x. Tasted 1/1/2026\nDecent wine.",
+        )
+        result = parse_rss_item(item)
+        assert result["score"] is None
+
+    def test_extracts_tasting_date(self):
+        item = self._make_item(
+            "https://ct.com/notes.asp?iWine=1#iNote2",
+            "Tasted by x. Tasted 4/11/2026\nGood.",
+        )
+        result = parse_rss_item(item)
+        assert result["tasting_date"] == "4/11/2026"
+
+    def test_missing_inote_returns_none(self):
+        item = self._make_item(
+            "https://ct.com/notes.asp?iWine=123",
+            "Tasted by x. Tasted 1/1/2026\nNote.",
+        )
+        result = parse_rss_item(item)
+        assert result is None
+
+    def test_missing_iwine_returns_none(self):
+        item = self._make_item(
+            "https://ct.com/notes.asp?something=else#iNote456",
+            "Tasted by x.\nNote.",
+        )
+        result = parse_rss_item(item)
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# TestParseRss
+# ---------------------------------------------------------------------------
+
+
+class TestParseRss:
+    def test_parses_sample_rss(self):
+        notes = parse_rss(SAMPLE_RSS)
+        assert len(notes) == 3
+
+    def test_first_note_fields(self):
+        notes = parse_rss(SAMPLE_RSS)
+        n = notes[0]
+        assert n["iWine"] == "5522345"
+        assert n["iNote"] == "12483504"
+        assert n["author"] == "nonodannecy"
+        assert n["score"] == 92
+        assert n["tasting_date"] == "4/11/2026"
+        assert "Cherry and raspberry" in (n["body"] or "")
+
+    def test_note_without_score(self):
+        notes = parse_rss(SAMPLE_RSS)
+        n = notes[1]  # winecritic42 has no score
+        assert n["score"] is None
+        assert n["author"] == "winecritic42"
+
+    def test_invalid_xml_returns_empty(self):
+        assert parse_rss("not xml at all") == []
+
+    def test_empty_channel_returns_empty(self):
+        xml = '<?xml version="1.0"?><rss><channel></channel></rss>'
+        assert parse_rss(xml) == []
+
+
+# ---------------------------------------------------------------------------
+# TestMergeNotes
+# ---------------------------------------------------------------------------
+
+
+class TestMergeNotes:
+    def _note(self, iwine, inote, score=None, tasting_date=None):
+        return {
+            "iWine": iwine,
+            "iNote": inote,
+            "title": "Wine",
+            "pubDate": "",
+            "author": "tester",
+            "score": score,
+            "body": "test note",
+            "tasting_date": tasting_date,
+        }
+
+    def test_merge_into_empty_cache(self):
+        cache, added = merge_notes({}, [self._note("1", "100")])
+        assert added == 1
+        assert "1" in cache
+        assert len(cache["1"]) == 1
+
+    def test_dedup_by_inote(self):
+        existing = {"1": [self._note("1", "100")]}
+        cache, added = merge_notes(existing, [self._note("1", "100")])
+        assert added == 0
+        assert len(cache["1"]) == 1
+
+    def test_adds_new_note_to_existing_wine(self):
+        existing = {"1": [self._note("1", "100")]}
+        cache, added = merge_notes(existing, [self._note("1", "101")])
+        assert added == 1
+        assert len(cache["1"]) == 2
+
+    def test_adds_note_for_new_wine(self):
+        existing = {"1": [self._note("1", "100")]}
+        cache, added = merge_notes(existing, [self._note("2", "200")])
+        assert added == 1
+        assert "2" in cache
+
+    def test_sorts_by_tasting_date_descending(self):
+        notes = [
+            self._note("1", "100", tasting_date="1/1/2026"),
+            self._note("1", "101", tasting_date="4/1/2026"),
+            self._note("1", "102", tasting_date="2/1/2026"),
+        ]
+        cache, _ = merge_notes({}, notes)
+        dates = [n["tasting_date"] for n in cache["1"]]
+        assert dates == ["4/1/2026", "2/1/2026", "1/1/2026"]
+
+    def test_multiple_new_notes_counted(self):
+        notes = [self._note("1", "100"), self._note("1", "101"), self._note("2", "200")]
+        cache, added = merge_notes({}, notes)
+        assert added == 3
+
+
+# ---------------------------------------------------------------------------
+# TestLoadCache
+# ---------------------------------------------------------------------------
+
+
+class TestLoadCache:
+    def test_missing_file_returns_empty(self, tmp_path):
+        assert load_cache(tmp_path / "nonexistent.json") == {}
+
+    def test_empty_file_returns_empty(self, tmp_path):
+        p = tmp_path / "empty.json"
+        p.write_text("")
+        assert load_cache(p) == {}
+
+    def test_valid_cache(self, tmp_path):
+        p = tmp_path / "cache.json"
+        data = {"123": [{"iNote": "1", "body": "test"}]}
+        p.write_text(json.dumps(data))
+        assert load_cache(p) == data
+
+    def test_invalid_json_returns_empty(self, tmp_path):
+        p = tmp_path / "bad.json"
+        p.write_text("{invalid json")
+        assert load_cache(p) == {}

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -17,6 +17,7 @@ Formula reference (from scoring.py):
 import pytest
 
 from scoring import (
+    community_score,
     composite_score,
     ct_score_component,
     diversity_score,
@@ -644,9 +645,11 @@ class TestCompositeScore:
         assert summer_score > winter_score  # summer = worse fit for bold red
 
     def test_weights_sum_to_one(self):
-        from scoring import W_CT, W_DIVERSITY, W_SEASON, W_WINDOW
+        from scoring import W_COMMUNITY, W_CT, W_DIVERSITY, W_SEASON, W_WINDOW
 
-        assert W_WINDOW + W_SEASON + W_DIVERSITY + W_CT == pytest.approx(1.0)
+        assert W_WINDOW + W_SEASON + W_DIVERSITY + W_CT + W_COMMUNITY == pytest.approx(
+            1.0
+        )
 
     def test_empty_placed_list(self):
         # Should work with empty placed list (diversity defaults to 100)
@@ -661,3 +664,83 @@ class TestCompositeScore:
         w = self._past_peak_wine()
         score = composite_score(w, "winter", 0, [])
         assert score < 50.0  # should be well below midpoint
+
+
+# ---------------------------------------------------------------------------
+# TestCommunityScore
+# ---------------------------------------------------------------------------
+
+
+class TestCommunityScore:
+    """community_score() returns 0–100 based on RSS community note signals."""
+
+    def _wine(self, iwine="123", ct=90):
+        return {"iWine": iwine, "CT": ct}
+
+    def _note(self, score=None, body="", tasting_date=None):
+        return {
+            "iWine": "123",
+            "iNote": "1",
+            "author": "tester",
+            "score": score,
+            "body": body,
+            "tasting_date": tasting_date,
+        }
+
+    def test_no_community_data_returns_neutral(self):
+        assert community_score(self._wine(), None) == pytest.approx(50.0)
+
+    def test_empty_community_data_returns_neutral(self):
+        assert community_score(self._wine(), {}) == pytest.approx(50.0)
+
+    def test_no_notes_for_wine_returns_neutral(self):
+        # Community data exists but not for this wine
+        cn = {"999": [self._note(score=90)]}
+        assert community_score(self._wine(), cn) == pytest.approx(50.0)
+
+    def test_disappointing_scores_bump_urgency(self):
+        # CT=90, recent scores averaging 85 → 5 point drop → bump
+        cn = {"123": [self._note(score=85) for _ in range(5)]}
+        score = community_score(self._wine(ct=90), cn)
+        assert score > 50.0  # bumped up
+
+    def test_better_than_expected_scores(self):
+        # CT=85, recent scores averaging 92 → positive surprise
+        cn = {"123": [self._note(score=92) for _ in range(5)]}
+        score = community_score(self._wine(ct=85), cn)
+        assert score > 50.0
+
+    def test_drink_now_text_bumps_score(self):
+        cn = {"123": [self._note(body="This wine is past prime, fading fast.")]}
+        score = community_score(self._wine(), cn)
+        assert score > 50.0
+
+    def test_hold_text_reduces_score(self):
+        cn = {"123": [self._note(body="Needs time. Too young and tight.")]}
+        score = community_score(self._wine(), cn)
+        assert score < 50.0
+
+    def test_score_clamped_to_range(self):
+        # Stack all positive signals
+        cn = {
+            "123": [
+                self._note(
+                    score=80, body="past prime, fading", tasting_date="12/1/2099"
+                )
+                for _ in range(10)
+            ]
+        }
+        score = community_score(self._wine(ct=90), cn)
+        assert 0.0 <= score <= 100.0
+
+    def test_mixed_drift_signals_cancel_out(self):
+        cn = {
+            "123": [
+                self._note(body="past prime"),
+                self._note(body="needs time"),
+            ]
+        }
+        # Equal drink-now and hold hits → no drift adjustment
+        score = community_score(self._wine(), cn)
+        # Should be close to neutral (only other sub-signals may apply)
+        assert 40.0 <= score <= 60.0


### PR DESCRIPTION
## Summary

- Add `fetch_community_notes.py` to poll CellarTracker's `rssnote.asp` RSS feed, parse community tasting notes, and maintain a cumulative JSON cache deduped by iNote
- Augment `generate_notes.py` Claude prompts with up to 3 recent community quotes per wine
- Add `community_score()` component to `scoring.py` (5% weight) using score drift, note velocity, and text-based window drift detection
- Rebalance scoring weights: window 50%, seasonal 25%, diversity 10%, CT quality 10%, community 5%
- RSS URL passed via env var (not CLI arg) to avoid CK token exposure in `ps` output
- Wire community notes through `generate_plan.py` scheduling so the 5% weight influences plan order

## Test plan

- [x] 214 unit tests pass (`python3 -m pytest tests/ -v`)
- [x] `pre-commit run --all-files` passes (ruff, pyright, shellcheck)
- [x] New tests cover RSS parsing, BBCode sanitization, dedup, cumulative merge, date sorting, community scoring signals

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)