### PR TITLE
LLM menu enrichment for richer pairing (#28)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,9 +24,11 @@ GENERATE PLAN (scripted — rules-based) → data/plan.json (staging)
 
 GENERATE NOTES (LLM — Claude Code CLI) → data/plan.json (augmented with CT notes + community notes)
 
-COMPARE & PAIR (scripted)
+ENRICH MENU (LLM — Claude Code CLI) → data/menu_enriched.json (cache) + data/menu_enriched_full.json
+
+COMPARE & PAIR (scripted, enriched-first fallback to keywords)
   ├── inventory + plan → data/report.json
-  └── menu + plan + inventory → data/pairing_suggestions.json
+  └── menu + plan + inventory + enriched → data/pairing_suggestions.json
 
 PUBLISH (atomic — site always has complete plan with notes)
   └── Copy plan.json + pairing_suggestions.json + report.json → site/
@@ -54,6 +56,7 @@ scripts/
   parse_inventory.py          — inventory.tsv → inventory.json
   parse_consumed.py           — consumed.tsv → consumed.json (consumption history)
   fetch_community_notes.py    — RSS feed → community_notes.json (cumulative cache, deduped by iNote)
+  enrich_menu.py              — LLM extraction of structured food features → menu_enriched.json (hash-keyed cache)
   parse_menu.py               — menu.ics → menu.json (Google Calendar .ics feed)
   compare.py                  — inventory.json + plan.json → report.json
   pairing.py                  — menu.json + plan.json + inventory.json → pairing_suggestions.json
@@ -67,6 +70,8 @@ data/                         — Staging area + generated artifacts (gitignored
   plan_previous.json          — Backup of previous live plan (for changelog diff)
   consumed.json               — Parsed consumption history (generated from consumed.tsv)
   community_notes.json        — Cumulative community tasting notes cache (from RSS, keyed by iWine)
+  menu_enriched.json          — LLM enrichment cache (keyed by text hash, persists across runs)
+  menu_enriched_full.json     — Full enriched menu with all entries (regenerated each run)
 conftest.py                   — pytest config: adds scripts/ to sys.path
 pyrightconfig.json            — Pyright type checking config
 pipeline.sh                   — Shared pipeline logic (sourced by fetch.sh and fetch_docker.sh)
@@ -169,8 +174,10 @@ Implemented in `scripts/generate_plan.py`:
 
 ## Wine-Food Pairing Engine ("The Sommelier")
 
-- `wine_keywords.py`: single source of truth for keywords and pairing rules
-- Three outcomes: Pairs Well (green), Sommelier Pick (blue), No Match (muted)
+- `wine_keywords.py`: single source of truth for keyword rules + enriched feature rules (protein, preparation, richness, spice, acidity, cuisine)
+- `enrich_menu.py`: LLM extracts 13-field structured food features from menu text, cached by text hash
+- Enriched-first fallback: try enriched features, fall back to keyword matching, fall back to neutral
+- Three outcomes: Pairs Well (green), Sommelier Pick (blue), No Match (muted) — each with confidence level (high/medium/low)
 - Suggestions prioritize urgent bottles in their drinking window
 - Each meal gets a unique suggestion
 - Varietal-aware: looks up inventory varietal for planned wines to improve matching

--- a/pipeline.sh
+++ b/pipeline.sh
@@ -125,8 +125,16 @@ fi
 log "==> Comparing inventory vs plan..."
 python3 scripts/compare.py data/inventory.json data/plan.json > data/report.json || { log "ERROR: Compare failed"; exit 1; }
 
+# --- ENRICH MENU (LLM — Claude Code CLI) ---
+if command -v claude &> /dev/null; then
+  log "==> Enriching menu entries (Claude)..."
+  python3 scripts/enrich_menu.py data/menu.json data/menu_enriched.json data/menu_enriched_full.json || log "WARNING: Menu enrichment failed — pairing will use keyword matching only"
+else
+  log "    Skipping menu enrichment — claude CLI not available"
+fi
+
 log "==> Generating pairing suggestions..."
-python3 scripts/pairing.py data/menu.json data/plan.json data/inventory.json > data/pairing_suggestions.json || { log "ERROR: Pairing failed"; exit 1; }
+python3 scripts/pairing.py data/menu.json data/plan.json data/inventory.json data/menu_enriched_full.json > data/pairing_suggestions.json || { log "ERROR: Pairing failed"; exit 1; }
 
 # --- PUBLISH atomically (site always has a complete plan with notes) ---
 log "==> Publishing to site/..."

--- a/scripts/enrich_menu.py
+++ b/scripts/enrich_menu.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""LLM-based menu enrichment for richer wine-food pairing.
+
+For each menu entry, extracts structured food features using Claude.
+Caches results keyed by raw text hash so unchanged entries aren't re-enriched.
+
+Usage: enrich_menu.py <menu.json> [menu_enriched.json]
+"""
+
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+from wine_utils import call_claude, extract_json
+
+ENRICHED_FIELDS = [
+    "protein",
+    "cut",
+    "preparation",
+    "sauce",
+    "sauce_intensity",
+    "sides",
+    "cuisine",
+    "richness",
+    "acidity",
+    "sweetness",
+    "spice_heat",
+    "dominant_flavor_axis",
+    "pairing_priorities",
+]
+
+
+def text_hash(text: str) -> str:
+    """Stable hash of menu text for cache keying."""
+    return hashlib.sha256(text.strip().lower().encode("utf-8")).hexdigest()[:16]
+
+
+def build_enrichment_prompt(entries: list[dict]) -> str:
+    """Build a prompt for Claude to extract structured food features."""
+    items = []
+    for i, entry in enumerate(entries):
+        items.append(f'{i}: "{entry["meal"]}"')
+
+    items_text = "\n".join(items)
+    return f"""Extract structured food features from each menu entry below.
+
+For each entry, produce a JSON object with these fields (omit any that don't apply):
+- protein: the main protein (e.g., "pork", "chicken", "salmon")
+- cut: specific cut if mentioned (e.g., "tenderloin", "thigh", "ribeye")
+- preparation: cooking method (e.g., "grilled", "braised", "roasted", "fried")
+- sauce: sauce description if present (e.g., "mustard pan sauce", "red wine reduction")
+- sauce_intensity: "light", "medium", or "heavy"
+- sides: array of side dishes (e.g., ["fingerlings", "kale"])
+- cuisine: cuisine type (e.g., "american", "italian", "thai", "mexican")
+- richness: overall dish richness — "light", "medium", or "rich"
+- acidity: "low", "medium", "medium-high", or "high"
+- sweetness: "low", "medium", or "high"
+- spice_heat: "none", "low", "medium", or "high"
+- dominant_flavor_axis: array of 1-3 dominant flavors (e.g., ["savory", "tangy"], ["sweet", "smoky"])
+- pairing_priorities: array of 1-3 wine pairing considerations (e.g., ["match acidity to mustard", "handle grilled char"])
+
+Rules:
+- Omit fields rather than guess — only include what's clearly implied by the menu text
+- For simple entries like "Leftovers" or "Pizza night", include what you can infer
+- Be concise in string values
+
+Return ONLY a JSON object mapping entry index to its features, like:
+{{"0": {{"protein": "pork", "preparation": "grilled", ...}}, "1": {{...}}}}
+
+Menu entries:
+{items_text}"""
+
+
+def load_cache(cache_path: Path) -> dict[str, dict]:
+    """Load enrichment cache (keyed by text hash)."""
+    if cache_path.exists() and cache_path.stat().st_size > 0:
+        try:
+            return json.loads(cache_path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError) as e:
+            print(f"WARNING: Could not load enrichment cache: {e}", file=sys.stderr)
+    return {}
+
+
+def enrich_menu(
+    menu_path: Path, cache_path: Path, output_path: Path | None = None
+) -> list[dict]:
+    """Enrich menu entries with LLM-extracted food features."""
+    menu = json.loads(menu_path.read_text(encoding="utf-8"))
+    cache = load_cache(cache_path)
+
+    # Separate cached vs uncached entries
+    results = []
+    to_enrich = []  # (index_in_results, entry)
+
+    for entry in menu:
+        h = text_hash(entry["meal"])
+        if h in cache:
+            results.append(
+                {"raw": entry["meal"], "hash": h, "enriched": cache[h], **entry}
+            )
+        else:
+            results.append({"raw": entry["meal"], "hash": h, "enriched": None, **entry})
+            to_enrich.append((len(results) - 1, entry))
+
+    if not to_enrich:
+        print(f"Menu enrichment: all {len(menu)} entries cached, nothing to enrich.")
+        _write_files(results, cache, cache_path, output_path)
+        return results
+
+    cache_hits = len(menu) - len(to_enrich)
+    print(f"Menu enrichment: {cache_hits} cached, {len(to_enrich)} to enrich...")
+
+    # Batch all uncached entries in one Claude call
+    entries_to_enrich = [e for _, e in to_enrich]
+    prompt = build_enrichment_prompt(entries_to_enrich)
+    response = call_claude(prompt)
+
+    if not response:
+        print("WARNING: Empty response from Claude — all entries unenriched")
+        _write_files(results, cache, cache_path, output_path)
+        return results
+
+    enrichments = extract_json(response)
+
+    # Map enrichments back to results
+    enriched_count = 0
+    for batch_idx, (result_idx, entry) in enumerate(to_enrich):
+        enriched = enrichments.get(str(batch_idx))
+        if enriched and isinstance(enriched, dict):
+            h = results[result_idx]["hash"]
+            results[result_idx]["enriched"] = enriched
+            cache[h] = enriched
+            enriched_count += 1
+
+    print(f"  Enriched {enriched_count}/{len(to_enrich)} entries.")
+
+    _write_files(results, cache, cache_path, output_path)
+    return results
+
+
+def _write_files(
+    results: list[dict],
+    cache: dict[str, dict],
+    cache_path: Path,
+    output_path: Path | None = None,
+) -> None:
+    """Write cache and full results atomically."""
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    files: list[tuple[Path, list | dict]] = [(cache_path, cache)]
+    if output_path:
+        files.append((output_path, results))
+    for path, data in files:
+        tmp = path.with_suffix(".tmp")
+        try:
+            tmp.write_text(
+                json.dumps(data, indent=2, ensure_ascii=False), encoding="utf-8"
+            )
+            tmp.replace(path)
+        except OSError as e:
+            print(f"ERROR: Failed to write {path}: {e}", file=sys.stderr)
+            tmp.unlink(missing_ok=True)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print(
+            "Usage: enrich_menu.py <menu.json> [cache.json] [output.json]",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    menu_path = Path(sys.argv[1])
+    cache_path = (
+        Path(sys.argv[2]) if len(sys.argv) > 2 else Path("data/menu_enriched.json")
+    )
+    output_path = (
+        Path(sys.argv[3]) if len(sys.argv) > 3 else Path("data/menu_enriched_full.json")
+    )
+
+    enrich_menu(menu_path, cache_path, output_path)

--- a/scripts/generate_notes.py
+++ b/scripts/generate_notes.py
@@ -12,9 +12,10 @@ Usage: generate_notes.py <plan.json> [notes.tsv] [foodtags.tsv] [community_notes
 
 import csv
 import json
-import subprocess
 import sys
 from pathlib import Path
+
+from wine_utils import call_claude, extract_json
 
 BATCH_SIZE = 20  # bottles per Claude call to stay within context
 
@@ -162,40 +163,6 @@ Return ONLY a JSON object mapping week numbers to notes, like:
 
 Wines:
 {bottle_list}"""
-
-
-def call_claude(prompt: str) -> str:
-    """Call Claude CLI with a prompt and return the response."""
-    try:
-        result = subprocess.run(
-            ["claude", "--print", "--model", "haiku", prompt],
-            capture_output=True,
-            text=True,
-            timeout=120,
-        )
-    except subprocess.TimeoutExpired:
-        print("WARNING: Claude CLI timed out", file=sys.stderr)
-        return ""
-    if result.returncode != 0:
-        print(
-            f"WARNING: Claude CLI returned {result.returncode}: {result.stderr}",
-            file=sys.stderr,
-        )
-        return ""
-    return result.stdout.strip()
-
-
-def extract_json(text: str) -> dict:
-    """Extract JSON object from Claude's response."""
-    start = text.find("{")
-    end = text.rfind("}") + 1
-    if start == -1 or end == 0:
-        return {}
-    try:
-        return json.loads(text[start:end])
-    except json.JSONDecodeError:
-        print("WARNING: Could not parse Claude response as JSON", file=sys.stderr)
-        return {}
 
 
 def generate_notes(

--- a/scripts/pairing.py
+++ b/scripts/pairing.py
@@ -14,7 +14,15 @@ import sys
 from datetime import date, datetime, timedelta
 from pathlib import Path
 
-from wine_keywords import PAIRING_RULES
+from wine_keywords import (
+    ENRICHED_ACIDITY_RULES,
+    ENRICHED_CUISINE_RULES,
+    ENRICHED_PREPARATION_RULES,
+    ENRICHED_PROTEIN_RULES,
+    ENRICHED_RICHNESS_RULES,
+    ENRICHED_SPICE_RULES,
+    PAIRING_RULES,
+)
 from wine_utils import CURRENT_YEAR, urgency_score
 
 
@@ -150,6 +158,65 @@ def find_best_bottle(
     return result
 
 
+def score_enriched_pairing(wine_name: str, enriched: dict) -> dict | None:
+    """Score a wine against enriched food features. Returns None if no signal."""
+    wine_lower = wine_name.lower()
+    matches = 0
+    mismatches = 0
+    signals = 0
+    suggested_styles: list[str] = []
+
+    def _check(rules: dict[str, list[str]], value: str | None) -> None:
+        nonlocal matches, mismatches, signals
+        if not value or value not in rules:
+            return
+        signals += 1
+        preferred = rules[value]
+        if any(style in wine_lower for style in preferred):
+            matches += 1
+        else:
+            mismatches += 1
+            suggested_styles.extend(preferred[:3])
+
+    _check(ENRICHED_PROTEIN_RULES, enriched.get("protein"))
+    _check(ENRICHED_PREPARATION_RULES, enriched.get("preparation"))
+    _check(ENRICHED_RICHNESS_RULES, enriched.get("richness"))
+    _check(ENRICHED_SPICE_RULES, enriched.get("spice_heat"))
+    _check(ENRICHED_ACIDITY_RULES, enriched.get("acidity"))
+    _check(ENRICHED_CUISINE_RULES, enriched.get("cuisine"))
+
+    if signals == 0:
+        return None
+
+    # Determine confidence based on number of signals
+    if signals >= 4:
+        confidence = "high"
+    elif signals >= 2:
+        confidence = "medium"
+    else:
+        confidence = "low"
+
+    if matches > 0 and mismatches == 0:
+        return {
+            "score": "good",
+            "confidence": confidence,
+            "details": f"wine matches enriched food profile ({matches}/{signals} features)",
+        }
+    if mismatches > 0 and matches == 0:
+        return {
+            "score": "poor",
+            "confidence": confidence,
+            "details": f"wine doesn't match enriched profile ({mismatches}/{signals} features)",
+            "suggested_styles": list(dict.fromkeys(suggested_styles)),
+        }
+    return {
+        "score": "partial",
+        "confidence": confidence,
+        "details": f"matches {matches}/{signals} enriched features",
+        "suggested_styles": list(dict.fromkeys(suggested_styles)),
+    }
+
+
 def score_pairing(wine_name: str, keywords: list[str]) -> dict:
     """Score how well a wine pairs with menu keywords."""
     wine_lower = wine_name.lower()
@@ -186,13 +253,28 @@ def score_pairing(wine_name: str, keywords: list[str]) -> dict:
     }
 
 
+def _build_enriched_index(enriched: list[dict]) -> dict[str, dict]:
+    """Build a date+meal → enriched features index."""
+    index: dict[str, dict] = {}
+    for entry in enriched:
+        enriched_data = entry.get("enriched")
+        if enriched_data:
+            key = f"{entry.get('date', '')}|{entry.get('meal', '')}"
+            index[key] = enriched_data
+    return index
+
+
 def suggest_pairings(
-    menu: list[dict], plan: list[dict], inventory: list[dict]
+    menu: list[dict],
+    plan: list[dict],
+    inventory: list[dict],
+    enriched: list[dict] | None = None,
 ) -> list[dict]:
     """Generate pairing suggestions for weeks with menu entries."""
     # Precompute indexes for O(1) lookups
     week_index = build_week_index(plan)
     precompute_searchable(inventory)
+    enriched_index = _build_enriched_index(enriched) if enriched else {}
 
     suggestions = []
     planned_wines = {}
@@ -215,23 +297,6 @@ def suggest_pairings(
             )
             continue
 
-        if not entry["keywords"]:
-            suggestions.append(
-                {
-                    "date": entry["date"],
-                    "meal": entry["meal"],
-                    "planned_wine": week.get("name", ""),
-                    "planned_vintage": week.get("vintage", ""),
-                    "planned_badge": week.get("badge", "red"),
-                    "status": "no_keywords",
-                    "pairing": {
-                        "score": "neutral",
-                        "details": "no match — enjoy the planned wine",
-                    },
-                }
-            )
-            continue
-
         # Look up varietal from inventory to improve pairing score accuracy
         inv_varietal = ""
         week_vintage = str(week.get("vintage", ""))
@@ -246,7 +311,34 @@ def suggest_pairings(
         wine_name = (
             f"{week.get('name', '')} {week.get('appellation', '')} {inv_varietal}"
         )
-        pairing = score_pairing(wine_name, entry["keywords"])
+
+        # Enriched-first fallback: try enriched features, then keyword matching
+        enriched_key = f"{entry['date']}|{entry['meal']}"
+        enriched_data = enriched_index.get(enriched_key)
+        pairing = None
+        if enriched_data:
+            pairing = score_enriched_pairing(wine_name, enriched_data)
+
+        if pairing is None:
+            if not entry["keywords"]:
+                suggestions.append(
+                    {
+                        "date": entry["date"],
+                        "meal": entry["meal"],
+                        "planned_wine": week.get("name", ""),
+                        "planned_vintage": week.get("vintage", ""),
+                        "planned_badge": week.get("badge", "red"),
+                        "status": "no_keywords",
+                        "pairing": {
+                            "score": "neutral",
+                            "confidence": "low",
+                            "details": "no match — enjoy the planned wine",
+                        },
+                    }
+                )
+                continue
+            pairing = score_pairing(wine_name, entry["keywords"])
+            pairing.setdefault("confidence", "medium")
 
         result = {
             "date": entry["date"],
@@ -278,7 +370,7 @@ def suggest_pairings(
 def main():
     if len(sys.argv) < 4:
         print(
-            "Usage: pairing.py <menu.json> <plan.json> <inventory.json>",
+            "Usage: pairing.py <menu.json> <plan.json> <inventory.json> [menu_enriched.json]",
             file=sys.stderr,
         )
         sys.exit(1)
@@ -292,7 +384,16 @@ def main():
     )
     inventory = json.loads(Path(sys.argv[3]).read_text())
 
-    suggestions = suggest_pairings(menu, plan, inventory)
+    enriched = None
+    if len(sys.argv) > 4:
+        enriched_path = Path(sys.argv[4])
+        if enriched_path.exists() and enriched_path.stat().st_size > 0:
+            try:
+                enriched = json.loads(enriched_path.read_text(encoding="utf-8"))
+            except (json.JSONDecodeError, OSError) as e:
+                print(f"WARNING: Could not load enriched menu: {e}", file=sys.stderr)
+
+    suggestions = suggest_pairings(menu, plan, inventory, enriched)
 
     result = {
         "generated": date.today().isoformat(),

--- a/scripts/wine_keywords.py
+++ b/scripts/wine_keywords.py
@@ -375,3 +375,72 @@ PAIRING_RULES = {
 
 # All recognized keywords — used by parse_menu.py for extraction
 ALL_KEYWORDS = set(PAIRING_RULES.keys())
+
+# ---------------------------------------------------------------------------
+# Enriched feature → wine preference mappings (used by pairing.py)
+# ---------------------------------------------------------------------------
+
+# Protein → preferred wine styles (same format as PAIRING_RULES["prefer"])
+ENRICHED_PROTEIN_RULES: dict[str, list[str]] = {
+    "beef": ["cabernet", "syrah", "merlot", "barolo", "bordeaux", "malbec"],
+    "lamb": ["cabernet", "syrah", "bordeaux", "rhône", "rhone"],
+    "pork": ["pinot noir", "rosé", "rose", "riesling", "chardonnay"],
+    "chicken": ["pinot noir", "chardonnay", "rosé", "rose"],
+    "turkey": ["pinot noir", "chardonnay", "gamay"],
+    "duck": ["pinot noir", "syrah", "gamay"],
+    "salmon": ["pinot noir", "chardonnay", "rosé", "rose"],
+    "tuna": ["pinot noir", "rosé", "rose"],
+    "fish": ["chardonnay", "sauvignon blanc", "pinot grigio"],
+    "shellfish": ["chardonnay", "sauvignon blanc", "sparkling"],
+    "shrimp": ["sauvignon blanc", "sparkling", "rosé", "rose"],
+    "tofu": ["pinot noir", "riesling", "sauvignon blanc"],
+    "vegetable": ["sauvignon blanc", "rosé", "rose", "pinot noir"],
+}
+
+# Preparation → wine style adjustments
+ENRICHED_PREPARATION_RULES: dict[str, list[str]] = {
+    "grilled": ["cabernet", "syrah", "malbec", "zinfandel"],
+    "braised": ["cabernet", "syrah", "barolo", "bordeaux"],
+    "roasted": ["pinot noir", "cabernet", "chardonnay"],
+    "smoked": ["syrah", "zinfandel", "malbec"],
+    "fried": ["sparkling", "rosé", "rose", "sauvignon blanc"],
+    "raw": ["sparkling", "sauvignon blanc", "pinot grigio"],
+    "poached": ["chardonnay", "pinot grigio", "riesling"],
+    "sautéed": ["pinot noir", "chardonnay", "sauvignon blanc"],
+    "steamed": ["riesling", "sauvignon blanc", "pinot grigio"],
+}
+
+# Richness → wine body preference
+ENRICHED_RICHNESS_RULES: dict[str, list[str]] = {
+    "light": ["sauvignon blanc", "pinot grigio", "rosé", "rose", "gamay", "riesling"],
+    "medium": ["pinot noir", "chardonnay", "merlot", "sangiovese", "barbera"],
+    "rich": ["cabernet", "syrah", "barolo", "bordeaux", "malbec", "zinfandel"],
+}
+
+# Spice heat → wine affinity
+ENRICHED_SPICE_RULES: dict[str, list[str]] = {
+    "medium": ["riesling", "rosé", "rose", "pinot noir"],
+    "high": ["riesling", "gewürztraminer", "rosé", "rose"],
+}
+
+# Acidity → wine acidity matching
+ENRICHED_ACIDITY_RULES: dict[str, list[str]] = {
+    "medium-high": ["sauvignon blanc", "sangiovese", "barbera", "riesling"],
+    "high": ["sauvignon blanc", "sangiovese", "barbera", "riesling", "sparkling"],
+}
+
+# Cuisine → wine region affinity
+ENRICHED_CUISINE_RULES: dict[str, list[str]] = {
+    "italian": ["sangiovese", "nebbiolo", "barbera", "pinot grigio", "chianti"],
+    "french": ["bordeaux", "burgundy", "pinot noir", "chardonnay", "syrah"],
+    "japanese": ["pinot noir", "gamay", "sparkling", "riesling"],
+    "thai": ["riesling", "gewürztraminer", "rosé", "rose"],
+    "mexican": ["malbec", "tempranillo", "rosé", "rose"],
+    "indian": ["riesling", "gewürztraminer", "rosé", "rose"],
+    "korean": ["riesling", "gamay", "pinot noir"],
+    "chinese": ["riesling", "pinot noir", "gamay"],
+    "spanish": ["tempranillo", "garnacha", "rosé", "rose"],
+    "greek": ["rosé", "rose", "sauvignon blanc"],
+    "mediterranean": ["rosé", "rose", "sangiovese", "tempranillo"],
+    "american": ["cabernet", "zinfandel", "chardonnay", "pinot noir"],
+}

--- a/scripts/wine_utils.py
+++ b/scripts/wine_utils.py
@@ -5,12 +5,17 @@ Symbols exported:
   CURRENT_YEAR      — current calendar year
   PRO_SCORE_FIELDS  — professional critic score field names
   TYPE_TO_BADGE     — CellarTracker Type → plan badge mapping
-  normalize     — canonical name normalizer (accent-aware)
-  urgency_score — bottle urgency priority (0 = most urgent)
+  normalize         — canonical name normalizer (accent-aware)
+  urgency_score     — bottle urgency priority (0 = most urgent)
+  call_claude       — invoke Claude CLI with a prompt
+  extract_json      — extract JSON object from LLM text response
 """
 
+import json
 import os
 import re
+import subprocess
+import sys
 import time
 from datetime import date
 
@@ -139,3 +144,42 @@ def apply_default_windows(inventory: list[dict]) -> int:
         count += 1
 
     return count
+
+
+# ---------------------------------------------------------------------------
+# Claude CLI helpers (shared by generate_notes.py and enrich_menu.py)
+# ---------------------------------------------------------------------------
+
+
+def call_claude(prompt: str) -> str:
+    """Call Claude CLI with a prompt and return the response."""
+    try:
+        result = subprocess.run(
+            ["claude", "--print", "--model", "haiku", prompt],
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+    except subprocess.TimeoutExpired:
+        print("WARNING: Claude CLI timed out", file=sys.stderr)
+        return ""
+    if result.returncode != 0:
+        print(
+            f"WARNING: Claude CLI returned {result.returncode}: {result.stderr}",
+            file=sys.stderr,
+        )
+        return ""
+    return result.stdout.strip()
+
+
+def extract_json(text: str) -> dict:
+    """Extract JSON object from Claude's response."""
+    start = text.find("{")
+    end = text.rfind("}") + 1
+    if start == -1 or end == 0:
+        return {}
+    try:
+        return json.loads(text[start:end])
+    except json.JSONDecodeError:
+        print("WARNING: Could not parse Claude response as JSON", file=sys.stderr)
+        return {}

--- a/tests/test_enrich_menu.py
+++ b/tests/test_enrich_menu.py
@@ -3,7 +3,8 @@
 import json
 
 
-from enrich_menu import build_enrichment_prompt, extract_json, load_cache, text_hash
+from enrich_menu import build_enrichment_prompt, load_cache, text_hash
+from wine_utils import extract_json
 
 
 class TestTextHash:

--- a/tests/test_enrich_menu.py
+++ b/tests/test_enrich_menu.py
@@ -1,0 +1,87 @@
+"""Tests for enrich_menu.py — prompt building, JSON extraction, cache."""
+
+import json
+
+
+from enrich_menu import build_enrichment_prompt, extract_json, load_cache, text_hash
+
+
+class TestTextHash:
+    def test_deterministic(self):
+        assert text_hash("Grilled chicken") == text_hash("Grilled chicken")
+
+    def test_case_insensitive(self):
+        assert text_hash("Grilled Chicken") == text_hash("grilled chicken")
+
+    def test_strips_whitespace(self):
+        assert text_hash("  chicken  ") == text_hash("chicken")
+
+    def test_different_text_different_hash(self):
+        assert text_hash("chicken") != text_hash("beef")
+
+    def test_returns_16_chars(self):
+        assert len(text_hash("anything")) == 16
+
+
+class TestBuildEnrichmentPrompt:
+    def test_includes_all_entries(self):
+        entries = [
+            {"meal": "Grilled chicken"},
+            {"meal": "Pasta primavera"},
+        ]
+        prompt = build_enrichment_prompt(entries)
+        assert "Grilled chicken" in prompt
+        assert "Pasta primavera" in prompt
+
+    def test_entries_are_indexed(self):
+        entries = [{"meal": "Steak"}, {"meal": "Fish"}]
+        prompt = build_enrichment_prompt(entries)
+        assert '0: "Steak"' in prompt
+        assert '1: "Fish"' in prompt
+
+    def test_mentions_required_fields(self):
+        prompt = build_enrichment_prompt([{"meal": "test"}])
+        assert "protein" in prompt
+        assert "preparation" in prompt
+        assert "richness" in prompt
+        assert "spice_heat" in prompt
+        assert "pairing_priorities" in prompt
+
+
+class TestExtractJson:
+    def test_extracts_json_from_text(self):
+        text = 'Here is the result: {"0": {"protein": "chicken"}} done.'
+        result = extract_json(text)
+        assert result == {"0": {"protein": "chicken"}}
+
+    def test_handles_no_json(self):
+        assert extract_json("no json here") == {}
+
+    def test_handles_invalid_json(self):
+        assert extract_json("{invalid: json}") == {}
+
+    def test_handles_nested_json(self):
+        text = '{"0": {"protein": "pork", "sides": ["kale", "potatoes"]}}'
+        result = extract_json(text)
+        assert result["0"]["sides"] == ["kale", "potatoes"]
+
+
+class TestLoadCache:
+    def test_missing_file_returns_empty(self, tmp_path):
+        assert load_cache(tmp_path / "nonexistent.json") == {}
+
+    def test_empty_file_returns_empty(self, tmp_path):
+        p = tmp_path / "empty.json"
+        p.write_text("")
+        assert load_cache(p) == {}
+
+    def test_valid_cache(self, tmp_path):
+        p = tmp_path / "cache.json"
+        data = {"abc123": {"protein": "chicken"}}
+        p.write_text(json.dumps(data))
+        assert load_cache(p) == data
+
+    def test_invalid_json_returns_empty(self, tmp_path):
+        p = tmp_path / "bad.json"
+        p.write_text("{bad")
+        assert load_cache(p) == {}

--- a/tests/test_pairing_enriched.py
+++ b/tests/test_pairing_enriched.py
@@ -1,0 +1,125 @@
+"""Tests for enriched pairing matching in pairing.py."""
+
+from pairing import _build_enriched_index, score_enriched_pairing
+
+
+class TestScoreEnrichedPairing:
+    """score_enriched_pairing() scores wine against enriched food features."""
+
+    def test_good_match_bold_red_with_beef(self):
+        # Cabernet should match beef + grilled + rich
+        enriched = {"protein": "beef", "preparation": "grilled", "richness": "rich"}
+        result = score_enriched_pairing("cabernet sauvignon reserve", enriched)
+        assert result is not None
+        assert result["score"] == "good"
+
+    def test_poor_match_white_with_beef(self):
+        # Sauvignon blanc should not match beef
+        enriched = {"protein": "beef", "preparation": "grilled", "richness": "rich"}
+        result = score_enriched_pairing("sauvignon blanc", enriched)
+        assert result is not None
+        assert result["score"] in ("poor", "partial")
+
+    def test_good_match_pinot_with_chicken(self):
+        enriched = {
+            "protein": "chicken",
+            "preparation": "roasted",
+            "richness": "medium",
+        }
+        result = score_enriched_pairing("pinot noir laurène", enriched)
+        assert result is not None
+        assert result["score"] == "good"
+
+    def test_no_signal_returns_none(self):
+        # Enriched data with no recognized features
+        enriched = {"sides": ["potatoes"]}
+        result = score_enriched_pairing("any wine", enriched)
+        assert result is None
+
+    def test_empty_enriched_returns_none(self):
+        result = score_enriched_pairing("any wine", {})
+        assert result is None
+
+    def test_confidence_high_with_many_signals(self):
+        enriched = {
+            "protein": "pork",
+            "preparation": "grilled",
+            "richness": "medium",
+            "cuisine": "american",
+        }
+        result = score_enriched_pairing("pinot noir", enriched)
+        assert result is not None
+        assert result["confidence"] == "high"
+
+    def test_confidence_low_with_one_signal(self):
+        enriched = {"protein": "chicken"}
+        result = score_enriched_pairing("pinot noir", enriched)
+        assert result is not None
+        assert result["confidence"] == "low"
+
+    def test_confidence_medium_with_two_signals(self):
+        enriched = {"protein": "fish", "richness": "light"}
+        result = score_enriched_pairing("sauvignon blanc", enriched)
+        assert result is not None
+        assert result["confidence"] == "medium"
+
+    def test_partial_match(self):
+        # Pinot noir matches chicken but not spice
+        enriched = {"protein": "chicken", "spice_heat": "high"}
+        result = score_enriched_pairing("pinot noir", enriched)
+        assert result is not None
+        assert result["score"] == "partial"
+
+    def test_spice_heat_favors_riesling(self):
+        # Riesling matches spice_heat=high but not protein=chicken → partial
+        enriched = {"protein": "chicken", "spice_heat": "high"}
+        result = score_enriched_pairing("riesling", enriched)
+        assert result is not None
+        assert result["score"] == "partial"
+
+    def test_spice_only_riesling_good(self):
+        # With only spice signal, riesling is a good match
+        enriched = {"spice_heat": "high"}
+        result = score_enriched_pairing("riesling", enriched)
+        assert result is not None
+        assert result["score"] == "good"
+
+    def test_acidity_matching(self):
+        enriched = {"acidity": "high"}
+        result = score_enriched_pairing("sangiovese chianti", enriched)
+        assert result is not None
+        assert result["score"] == "good"
+
+    def test_cuisine_matching_italian(self):
+        enriched = {"cuisine": "italian", "richness": "medium"}
+        result = score_enriched_pairing("sangiovese chianti classico", enriched)
+        assert result is not None
+        assert result["score"] == "good"
+
+    def test_suggested_styles_on_mismatch(self):
+        enriched = {"protein": "beef", "richness": "rich"}
+        result = score_enriched_pairing("riesling", enriched)
+        assert result is not None
+        assert "suggested_styles" in result
+        assert len(result["suggested_styles"]) > 0
+
+
+class TestBuildEnrichedIndex:
+    def test_builds_index_from_enriched_list(self):
+        enriched = [
+            {
+                "date": "2026-04-20",
+                "meal": "Grilled chicken",
+                "enriched": {"protein": "chicken"},
+            }
+        ]
+        index = _build_enriched_index(enriched)
+        assert "2026-04-20|Grilled chicken" in index
+
+    def test_skips_entries_without_enriched(self):
+        enriched = [{"date": "2026-04-20", "meal": "Leftovers", "enriched": None}]
+        index = _build_enriched_index(enriched)
+        assert len(index) == 0
+
+    def test_empty_list(self):
+        assert _build_enriched_index([]) == {}


### PR DESCRIPTION
## Summary

- Add `enrich_menu.py` — LLM extraction of 13-field structured food features (protein, cut, preparation, sauce, richness, acidity, spice_heat, cuisine, etc.) via Claude CLI, with hash-keyed cache to avoid re-enriching unchanged entries
- Enriched-first fallback in `pairing.py`: try enriched features, fall back to keyword matching, fall back to neutral
- Add confidence level (high/medium/low) to all pairing results based on signal count
- Enriched feature rules (protein, preparation, richness, spice, acidity, cuisine) added to `wine_keywords.py` as single source of truth
- `call_claude()` and `extract_json()` deduplicated into `wine_utils.py` (shared by `generate_notes.py` and `enrich_menu.py`)
- Follow-up issue #45 created for UI confidence level display

## Test plan

- [x] 247 unit tests pass (`python3 -m pytest tests/ -v`)
- [x] `pre-commit run --all-files` passes (ruff, pyright, shellcheck)
- [x] New tests cover enriched pairing scoring, confidence levels, prompt building, cache loading, text hashing, enriched index building

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)