### PR TITLE
Add morning digest email with wine and menu pairings (#29)

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -17,6 +17,13 @@ CT_COMMUNITY_NOTES_RSS="op://<vault>/<item>/RSS"
 # Healthchecks.io ping key (1Password secret reference)
 HEALTHCHECK_PING_KEY="op://<vault>/<item>/ping_key"
 
+# SMTP credentials for morning digest email (1Password secret references)
+SMTP_USERNAME="op://<vault>/<item>/username"
+SMTP_PASSWORD="op://<vault>/<item>/password"
+
+# Digest email recipients (comma-separated)
+DIGEST_RECIPIENTS="user@example.com"
+
 # Home Assistant SSH target for pushing thisweek.json and today.json
 # Format: user@host (SSH key must be mounted into the container)
 HA_SSH_TARGET=hassio@homeassistant.unibrain.org

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,11 @@ COMPARE & PAIR (scripted, enriched-first fallback to keywords)
 
 PUBLISH (atomic — site always has complete plan with notes)
   └── Copy plan.json + pairing_suggestions.json + report.json → site/
+
+GENERATE DIGEST → site/digest.json + site/digest.html (only when menu exists for today)
+
+SEND DIGEST (separate 8am cron via supercronic)
+  └── Gmail SMTP → configured recipients (idempotent, skips routine days)
 ```
 
 ## Directory Structure
@@ -57,6 +62,8 @@ scripts/
   parse_consumed.py           — consumed.tsv → consumed.json (consumption history)
   fetch_community_notes.py    — RSS feed → community_notes.json (cumulative cache, deduped by iNote)
   enrich_menu.py              — LLM extraction of structured food features → menu_enriched.json (hash-keyed cache)
+  generate_digest.py          — Morning digest: tonight's wine + menu pairings → digest.json + digest.html
+  send_digest.py              — Send digest via Gmail SMTP (--dry-run, --force, idempotent)
   parse_menu.py               — menu.ics → menu.json (Google Calendar .ics feed)
   compare.py                  — inventory.json + plan.json → report.json
   pairing.py                  — menu.json + plan.json + inventory.json → pairing_suggestions.json
@@ -72,6 +79,7 @@ data/                         — Staging area + generated artifacts (gitignored
   community_notes.json        — Cumulative community tasting notes cache (from RSS, keyed by iWine)
   menu_enriched.json          — LLM enrichment cache (keyed by text hash, persists across runs)
   menu_enriched_full.json     — Full enriched menu with all entries (regenerated each run)
+  digest_last_sent.txt        — Idempotency state file for send_digest.py (date of last send)
 conftest.py                   — pytest config: adds scripts/ to sys.path
 pyrightconfig.json            — Pyright type checking config
 pipeline.sh                   — Shared pipeline logic (sourced by fetch.sh and fetch_docker.sh)

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -23,8 +23,11 @@ nginx
 
 # Set up periodic sync with supercronic (runs as non-root)
 SCHEDULE="${SYNC_SCHEDULE:-0 2 * * *}"
+DIGEST_SCHEDULE="${DIGEST_SEND_SCHEDULE:-0 8 * * *}"
 echo "${SCHEDULE} cd /app && bash fetch_docker.sh" > /tmp/crontab
+echo "${DIGEST_SCHEDULE} cd /app && bash send_digest.sh" >> /tmp/crontab
 echo "    Scheduled sync: ${SCHEDULE}"
+echo "    Scheduled digest: ${DIGEST_SCHEDULE}"
 supercronic /tmp/crontab &
 
 # Run the pipeline once (site is already serving)

--- a/pipeline.sh
+++ b/pipeline.sh
@@ -53,6 +53,9 @@ GOOGLE_CALENDAR_ICS_URL=$(op read "$GOOGLE_CALENDAR_ICS_URL") || { log "ERROR: F
 export CLAUDE_CODE_OAUTH_TOKEN
 CLAUDE_CODE_OAUTH_TOKEN=$(op read "$CLAUDE_CODE_OAUTH_TOKEN") || { log "WARNING: Failed to resolve Claude OAuth token from 1Password"; }
 CT_COMMUNITY_NOTES_RSS=$(op read "$CT_COMMUNITY_NOTES_RSS") || { log "WARNING: Failed to resolve community notes RSS URL from 1Password — continuing without community notes"; }
+export SMTP_USERNAME SMTP_PASSWORD DIGEST_RECIPIENTS
+SMTP_USERNAME=$(op read "$SMTP_USERNAME") || { log "WARNING: Failed to resolve SMTP username — digest email disabled"; }
+SMTP_PASSWORD=$(op read "$SMTP_PASSWORD") || { log "WARNING: Failed to resolve SMTP password — digest email disabled"; }
 
 CT_BASE="https://www.cellartracker.com/xlquery.asp?User=${CT_USERNAME}&Password=${CT_PASSWORD}&Format=tab"
 
@@ -162,6 +165,10 @@ if [[ -n "${HA_SSH_TARGET:-}" ]] && [[ -f "${HA_SSH_KEY}" ]]; then
 else
   log "    Skipping Home Assistant push — HA_SSH_TARGET or SSH key not configured"
 fi
+
+# --- GENERATE DIGEST ---
+log "==> Generating morning digest..."
+python3 scripts/generate_digest.py || { RC=$?; if [ "$RC" -eq 2 ]; then log "    Digest: nothing to send (routine day)"; else log "WARNING: Digest generation failed"; fi; }
 
 log "==> Sync complete."
 

--- a/scripts/generate_digest.py
+++ b/scripts/generate_digest.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python3
+"""Generate a morning digest for tonight's wine and menu pairings.
+
+Reads site/plan.json and site/pairing_suggestions.json. Produces
+site/digest.json (structured) and site/digest.html (branded email).
+
+Only generates content when there's a menu entry for today — this is
+a "go pull this wine" reminder, not a daily newsletter.
+
+Exit codes:
+  0 — digest generated with content worth sending
+  2 — nothing to send (no menu today)
+
+Usage: generate_digest.py [--force]
+"""
+
+import json
+import os
+import sys
+import time
+from datetime import date, datetime
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+# Ensure TZ env var is respected
+if "TZ" in os.environ:
+    time.tzset()
+
+from wine_utils import find_current_week
+
+LOCAL_TZ = ZoneInfo("America/Los_Angeles")
+
+
+def _today_local() -> date:
+    return datetime.now(LOCAL_TZ).date()
+
+
+def find_meals_for_date(suggestions: list[dict], target: str) -> list[dict]:
+    """Find all pairing suggestions for a specific date."""
+    return [s for s in suggestions if s.get("date") == target]
+
+
+def build_digest(
+    plan_path: Path,
+    pairing_path: Path,
+) -> dict:
+    """Build the digest data structure."""
+    today = _today_local()
+    today_str = today.isoformat()
+
+    plan_data = json.loads(plan_path.read_text(encoding="utf-8"))
+    all_weeks = plan_data.get("allWeeks", [])
+
+    pairing_data = json.loads(pairing_path.read_text(encoding="utf-8"))
+    suggestions = pairing_data.get("suggestions", [])
+
+    current_week = find_current_week(all_weeks, today)
+    today_pairings = find_meals_for_date(suggestions, today_str)
+
+    has_content = len(today_pairings) > 0
+
+    digest: dict = {
+        "date": today_str,
+        "date_display": today.strftime("%A, %B %-d, %Y"),
+        "has_content": has_content,
+        "wine": None,
+        "pairings": today_pairings,
+    }
+
+    if current_week:
+        digest["wine"] = {
+            "name": current_week.get("name", ""),
+            "vintage": current_week.get("vintage", ""),
+            "badge": current_week.get("badge", ""),
+            "note": current_week.get("note", ""),
+            "window": current_week.get("window"),
+            "score": current_week.get("score"),
+            "location": current_week.get("location", ""),
+            "urgent": current_week.get("urgent", False),
+        }
+
+    return digest
+
+
+def _badge_color(badge: str) -> str:
+    colors = {
+        "sparkling": "#29abe0",
+        "rose": "#e83e8c",
+        "white": "#c49b2a",
+        "red": "#8b3a3a",
+    }
+    return colors.get(badge, "#8b3a3a")
+
+
+def _badge_icon(badge: str) -> str:
+    icons = {"sparkling": "🥂", "rose": "🌹", "white": "🥃", "red": "🍷"}
+    return icons.get(badge, "🍷")
+
+
+def _pairing_color(score: str) -> str:
+    return {"good": "#5cb85c", "partial": "#f0ad4e", "poor": "#d9534f"}.get(
+        score, "#dfd7ca"
+    )
+
+
+def format_digest_html(digest: dict) -> str:
+    """Format the digest as a branded HTML email."""
+    wine = digest.get("wine")
+    pairings = digest.get("pairings", [])
+    date_display = digest.get("date_display", digest["date"])
+
+    # Wine section
+    wine_html = ""
+    if wine:
+        badge_color = _badge_color(wine["badge"])
+        badge_icon = _badge_icon(wine["badge"])
+        urgent_html = ""
+        if wine.get("urgent"):
+            urgent_html = '<div style="color:#d9534f;font-size:13px;font-weight:600;margin-top:6px;">⚠ Past peak — drink now</div>'
+
+        meta_parts = []
+        if wine.get("window"):
+            meta_parts.append(f"Window: {wine['window']}")
+        if wine.get("score"):
+            meta_parts.append(f"Score: {wine['score']}")
+        if wine.get("location"):
+            meta_parts.append(f"Location: {wine['location']}")
+        meta_html = " &nbsp;·&nbsp; ".join(meta_parts)
+
+        note_html = ""
+        if wine.get("note"):
+            note_html = f'<div style="color:#3e3f3a;font-size:14px;margin-top:8px;line-height:1.5;font-style:italic;">{wine["note"]}</div>'
+
+        wine_html = f"""
+<tr><td style="padding:28px 32px 0;">
+  <div style="font-size:11px;text-transform:uppercase;letter-spacing:1.5px;color:#8e8c84;font-weight:600;margin-bottom:10px;">Tonight's Wine</div>
+  <table width="100%" cellpadding="0" cellspacing="0" style="background:#f8f5f0;border-radius:8px;border:1px solid #dfd7ca;">
+  <tr><td style="padding:20px 24px;">
+    <table cellpadding="0" cellspacing="0"><tr>
+      <td style="vertical-align:top;padding-right:14px;">
+        <div style="width:36px;height:36px;border-radius:50%;background:{badge_color};text-align:center;line-height:36px;font-size:16px;">{badge_icon}</div>
+      </td>
+      <td>
+        <div style="font-size:20px;font-weight:600;color:#3e3f3a;">{wine["vintage"]} {wine["name"]}</div>
+        <div style="color:#8e8c84;font-size:14px;margin-top:4px;">{meta_html}</div>
+        {urgent_html}
+        {note_html}
+      </td>
+    </tr></table>
+  </td></tr>
+  </table>
+</td></tr>"""
+
+    # Pairings section
+    pairings_html = ""
+    if pairings:
+        cards = []
+        for p in pairings:
+            meal = p.get("meal", "")
+            pairing = p.get("pairing", {})
+            score = pairing.get("score", "neutral")
+            color = _pairing_color(score)
+
+            status_icon = {"good": "✅", "partial": "🟡", "poor": "❌"}.get(score, "—")
+            status_text = {
+                "good": "Planned wine pairs well",
+                "partial": "Partial match with planned wine",
+                "poor": "No match with planned wine",
+                "neutral": "Enjoy the planned wine",
+            }.get(score, pairing.get("details", ""))
+
+            suggestion_html = ""
+            sb = p.get("suggested_bottle")
+            if sb:
+                sb_meta = f"Window: {sb.get('window', '?')}"
+                if sb.get("urgency"):
+                    sb_meta += f" · {sb['urgency']}"
+                suggestion_html = f"""
+      <div style="background:#d6dfe7;border-radius:6px;padding:10px 14px;margin-top:8px;">
+        <div style="font-size:12px;color:#325d88;font-weight:600;text-transform:uppercase;letter-spacing:0.5px;">Sommelier Suggests</div>
+        <div style="font-size:14px;font-weight:500;margin-top:4px;">{sb.get("vintage")} {sb.get("wine")}</div>
+        <div style="font-size:12px;color:#8e8c84;margin-top:2px;">{sb_meta}</div>
+      </div>"""
+
+            cards.append(f"""
+  <table width="100%" cellpadding="0" cellspacing="0" style="margin-bottom:8px;border-radius:8px;border:1px solid #dfd7ca;overflow:hidden;">
+  <tr>
+    <td width="4" style="background:{color};"></td>
+    <td style="padding:14px 18px;">
+      <div style="font-size:15px;font-weight:500;">{meal}</div>
+      <div style="color:{color};font-size:13px;margin-top:3px;">{status_icon} {status_text}</div>
+      {suggestion_html}
+    </td>
+  </tr>
+  </table>""")
+
+        pairings_html = f"""
+<tr><td style="padding:24px 32px 0;">
+  <div style="font-size:11px;text-transform:uppercase;letter-spacing:1.5px;color:#8e8c84;font-weight:600;margin-bottom:10px;">Tonight's Menu</div>
+  {"".join(cards)}
+</td></tr>"""
+
+    return f"""<!DOCTYPE html>
+<html><head><meta charset="utf-8"></head>
+<body style="margin:0;padding:0;background:#f8f5f0;font-family:'Helvetica Neue',Helvetica,Arial,sans-serif;color:#3e3f3a;">
+<table width="100%" cellpadding="0" cellspacing="0" style="background:#f8f5f0;padding:20px 0;">
+<tr><td align="center">
+<table width="600" cellpadding="0" cellspacing="0" style="background:#ffffff;border-radius:12px;overflow:hidden;box-shadow:0 2px 8px rgba(0,0,0,0.08);">
+
+<tr><td style="background:linear-gradient(135deg,#3e3f3a 0%,#4a4b46 100%);padding:28px 32px;text-align:center;">
+  <div style="font-size:28px;font-weight:700;color:#ffffff;letter-spacing:0.5px;">
+    🍷 <em style="font-style:italic;font-weight:300;">The</em> Sommelier
+  </div>
+  <div style="color:#c5bdb0;font-size:13px;margin-top:6px;letter-spacing:1px;text-transform:uppercase;">
+    {date_display}
+  </div>
+</td></tr>
+
+{wine_html}
+{pairings_html}
+
+<tr><td style="padding:28px 32px;text-align:center;">
+  <div style="color:#c5bdb0;font-size:12px;">
+    The Sommelier · Drink the right bottles at the right time
+  </div>
+</td></tr>
+
+</table>
+</td></tr>
+</table>
+</body></html>"""
+
+
+def main() -> None:
+    force = "--force" in sys.argv
+
+    plan_path = Path("site/plan.json")
+    pairing_path = Path("site/pairing_suggestions.json")
+
+    if not plan_path.exists():
+        print("ERROR: site/plan.json not found", file=sys.stderr)
+        sys.exit(1)
+    if not pairing_path.exists():
+        print("ERROR: site/pairing_suggestions.json not found", file=sys.stderr)
+        sys.exit(1)
+
+    digest = build_digest(plan_path, pairing_path)
+    html = format_digest_html(digest)
+
+    Path("site/digest.json").write_text(
+        json.dumps(digest, indent=2, ensure_ascii=False), encoding="utf-8"
+    )
+    Path("site/digest.html").write_text(html, encoding="utf-8")
+
+    print(f"Digest generated for {digest['date']}")
+
+    if not digest["has_content"] and not force:
+        print("  No menu today — nothing to send")
+        sys.exit(2)
+
+    print(f"  {len(digest['pairings'])} meal(s) on the menu")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/send_digest.py
+++ b/scripts/send_digest.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Send the morning digest via email (Gmail SMTP).
+
+Reads site/digest.json and site/digest.html, sends via SMTP with STARTTLS.
+Idempotent: tracks last-sent date to prevent double-sends.
+
+Usage: send_digest.py [--dry-run] [--force]
+  --dry-run  Print the email subject and recipient list without sending
+  --force    Send even if digest has no content or already sent today
+"""
+
+import json
+import os
+import smtplib
+import sys
+from datetime import date
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+from pathlib import Path
+
+STATE_FILE = Path("data/digest_last_sent.txt")
+DIGEST_JSON = Path("site/digest.json")
+DIGEST_HTML = Path("site/digest.html")
+
+
+def already_sent_today() -> bool:
+    """Check if digest was already sent today."""
+    if not STATE_FILE.exists():
+        return False
+    last_sent = STATE_FILE.read_text().strip()
+    return last_sent == date.today().isoformat()
+
+
+def mark_sent() -> None:
+    """Record that digest was sent today."""
+    STATE_FILE.parent.mkdir(parents=True, exist_ok=True)
+    STATE_FILE.write_text(date.today().isoformat())
+
+
+def build_email(
+    digest: dict, html_body: str, sender: str, recipients: list[str]
+) -> MIMEMultipart:
+    """Build the email message with HTML body."""
+    wine = digest.get("wine")
+    if wine:
+        subject = f"Tonight: {wine['vintage']} {wine['name']}"
+    else:
+        subject = "The Sommelier — Daily Digest"
+
+    msg = MIMEMultipart("alternative")
+    msg["Subject"] = subject
+    msg["From"] = sender
+    msg["To"] = ", ".join(recipients)
+    msg.attach(MIMEText(html_body, "html", "utf-8"))
+
+    return msg
+
+
+def send_email(msg: MIMEMultipart, username: str, password: str) -> None:
+    """Send via Gmail SMTP with STARTTLS."""
+    with smtplib.SMTP("smtp.gmail.com", 587) as server:
+        server.starttls()
+        server.login(username, password)
+        server.send_message(msg)
+
+
+def main() -> None:
+    dry_run = "--dry-run" in sys.argv
+    force = "--force" in sys.argv
+
+    if not DIGEST_JSON.exists():
+        print(
+            "ERROR: site/digest.json not found — run generate_digest.py first",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    digest = json.loads(DIGEST_JSON.read_text(encoding="utf-8"))
+    html_body = DIGEST_HTML.read_text(encoding="utf-8") if DIGEST_HTML.exists() else ""
+
+    # Check if there's content worth sending
+    if not digest.get("has_content") and not force:
+        print("Nothing to send (no menu today). Use --force to override.")
+        return
+
+    # Idempotency check
+    if already_sent_today() and not force:
+        print(
+            f"Digest already sent today ({date.today().isoformat()}). "
+            "Use --force to resend."
+        )
+        return
+
+    # Resolve SMTP credentials
+    smtp_username = os.environ.get("SMTP_USERNAME", "")
+    smtp_password = os.environ.get("SMTP_PASSWORD", "")
+    recipients_str = os.environ.get("DIGEST_RECIPIENTS", "")
+
+    if not dry_run and (not smtp_username or not smtp_password or not recipients_str):
+        print(
+            "ERROR: SMTP_USERNAME, SMTP_PASSWORD, and DIGEST_RECIPIENTS must be set",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    recipients = [r.strip() for r in recipients_str.split(",") if r.strip()]
+
+    msg = build_email(digest, html_body, smtp_username, recipients)
+
+    if dry_run:
+        print("=== DRY RUN ===")
+        print(f"From: {smtp_username or '(not set)'}")
+        print(f"To: {', '.join(recipients) if recipients else '(no recipients)'}")
+        print(f"Subject: {msg['Subject']}")
+        print(f"Body: {len(html_body)} bytes HTML")
+        print("=== END DRY RUN ===")
+        return
+
+    try:
+        send_email(msg, smtp_username, smtp_password)
+    except Exception as e:
+        print(f"ERROR: Failed to send digest email: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    mark_sent()
+    print(f"Digest sent to {', '.join(recipients)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/send_digest.py
+++ b/scripts/send_digest.py
@@ -13,28 +13,35 @@ import json
 import os
 import smtplib
 import sys
-from datetime import date
+from datetime import datetime
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from pathlib import Path
+from zoneinfo import ZoneInfo
 
 STATE_FILE = Path("data/digest_last_sent.txt")
 DIGEST_JSON = Path("site/digest.json")
 DIGEST_HTML = Path("site/digest.html")
+LOCAL_TZ = ZoneInfo("America/Los_Angeles")
+
+
+def _today_local() -> str:
+    """Return today's date in Pacific time as ISO string."""
+    return datetime.now(LOCAL_TZ).date().isoformat()
 
 
 def already_sent_today() -> bool:
-    """Check if digest was already sent today."""
+    """Check if digest was already sent today (Pacific time)."""
     if not STATE_FILE.exists():
         return False
     last_sent = STATE_FILE.read_text().strip()
-    return last_sent == date.today().isoformat()
+    return last_sent == _today_local()
 
 
 def mark_sent() -> None:
-    """Record that digest was sent today."""
+    """Record that digest was sent today (Pacific time)."""
     STATE_FILE.parent.mkdir(parents=True, exist_ok=True)
-    STATE_FILE.write_text(date.today().isoformat())
+    STATE_FILE.write_text(_today_local())
 
 
 def build_email(
@@ -76,7 +83,20 @@ def main() -> None:
         sys.exit(1)
 
     digest = json.loads(DIGEST_JSON.read_text(encoding="utf-8"))
-    html_body = DIGEST_HTML.read_text(encoding="utf-8") if DIGEST_HTML.exists() else ""
+
+    if not DIGEST_HTML.exists():
+        print("ERROR: site/digest.html not found", file=sys.stderr)
+        sys.exit(1)
+    html_body = DIGEST_HTML.read_text(encoding="utf-8")
+
+    # Check if digest is for today (guard against stale data from failed pipeline)
+    today_str = _today_local()
+    if digest.get("date") != today_str and not force:
+        print(
+            f"Digest is for {digest.get('date')}, not today ({today_str}). "
+            "Use --force to override."
+        )
+        return
 
     # Check if there's content worth sending
     if not digest.get("has_content") and not force:
@@ -85,10 +105,7 @@ def main() -> None:
 
     # Idempotency check
     if already_sent_today() and not force:
-        print(
-            f"Digest already sent today ({date.today().isoformat()}). "
-            "Use --force to resend."
-        )
+        print(f"Digest already sent today ({today_str}). Use --force to resend.")
         return
 
     # Resolve SMTP credentials
@@ -118,7 +135,7 @@ def main() -> None:
 
     try:
         send_email(msg, smtp_username, smtp_password)
-    except Exception as e:
+    except smtplib.SMTPException as e:
         print(f"ERROR: Failed to send digest email: {e}", file=sys.stderr)
         sys.exit(1)
 

--- a/scripts/thisweek.py
+++ b/scripts/thisweek.py
@@ -9,26 +9,9 @@ Output: the matching allWeeks entry as JSON to stdout.
 import argparse
 import json
 import sys
-from datetime import date, datetime, timedelta
 from pathlib import Path
 
-
-def find_current_week(all_weeks: list[dict]) -> dict:
-    """Return the week entry that contains today, or the first entry as fallback."""
-    today = date.today()
-
-    for week in all_weeks:
-        raw = week.get("date", "")
-        try:
-            week_monday = datetime.strptime(raw, "%b %d, %Y").date()
-        except ValueError:
-            continue
-        # The week spans Monday through Sunday (7 days)
-        if week_monday <= today < week_monday + timedelta(days=7):
-            return week
-
-    # Fallback: return the first entry
-    return all_weeks[0]
+from wine_utils import find_current_week
 
 
 def main() -> None:
@@ -49,7 +32,7 @@ def main() -> None:
         print("Error: allWeeks is empty", file=sys.stderr)
         sys.exit(1)
 
-    entry = find_current_week(all_weeks)
+    entry = find_current_week(all_weeks) or all_weeks[0]
     json.dump(entry, sys.stdout, indent=2, ensure_ascii=False)
     print()  # trailing newline
 

--- a/scripts/wine_utils.py
+++ b/scripts/wine_utils.py
@@ -147,6 +147,30 @@ def apply_default_windows(inventory: list[dict]) -> int:
 
 
 # ---------------------------------------------------------------------------
+# Week lookup
+# ---------------------------------------------------------------------------
+
+
+def find_current_week(all_weeks: list[dict], target: date | None = None) -> dict | None:
+    """Find the plan week containing the target date (default: today).
+
+    Returns None if no matching week is found.
+    """
+    from datetime import datetime, timedelta
+
+    target = target or date.today()
+    for week in all_weeks:
+        raw = week.get("date", "")
+        try:
+            week_monday = datetime.strptime(raw, "%b %d, %Y").date()
+        except ValueError:
+            continue
+        if week_monday <= target < week_monday + timedelta(days=7):
+            return week
+    return None
+
+
+# ---------------------------------------------------------------------------
 # Claude CLI helpers (shared by generate_notes.py and enrich_menu.py)
 # ---------------------------------------------------------------------------
 

--- a/send_digest.sh
+++ b/send_digest.sh
@@ -7,9 +7,11 @@ set -a
 source .env
 set +a
 
-# Resolve SMTP credentials from 1Password
+# Resolve SMTP credentials from 1Password (skip for --dry-run)
 export SMTP_USERNAME SMTP_PASSWORD DIGEST_RECIPIENTS
-SMTP_USERNAME=$(op read "$SMTP_USERNAME") || { echo "WARNING: Failed to resolve SMTP username"; exit 1; }
-SMTP_PASSWORD=$(op read "$SMTP_PASSWORD") || { echo "WARNING: Failed to resolve SMTP password"; exit 1; }
+if [[ ! " $* " =~ " --dry-run " ]]; then
+  SMTP_USERNAME=$(op read "$SMTP_USERNAME") || { echo "ERROR: Failed to resolve SMTP username"; exit 1; }
+  SMTP_PASSWORD=$(op read "$SMTP_PASSWORD") || { echo "ERROR: Failed to resolve SMTP password"; exit 1; }
+fi
 
 python3 scripts/send_digest.py "$@"

--- a/send_digest.sh
+++ b/send_digest.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")"
+
+# Source .env for 1Password references
+set -a
+source .env
+set +a
+
+# Resolve SMTP credentials from 1Password
+export SMTP_USERNAME SMTP_PASSWORD DIGEST_RECIPIENTS
+SMTP_USERNAME=$(op read "$SMTP_USERNAME") || { echo "WARNING: Failed to resolve SMTP username"; exit 1; }
+SMTP_PASSWORD=$(op read "$SMTP_PASSWORD") || { echo "WARNING: Failed to resolve SMTP password"; exit 1; }
+
+python3 scripts/send_digest.py "$@"

--- a/tests/test_generate_digest.py
+++ b/tests/test_generate_digest.py
@@ -1,0 +1,237 @@
+"""Tests for generate_digest.py — digest generation logic."""
+
+import json
+
+
+from generate_digest import (
+    build_digest,
+    find_meals_for_date,
+    format_digest_html,
+)
+from wine_utils import find_current_week
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _week(date_str: str, name: str = "Test Wine", vintage: str = "2020") -> dict:
+    return {
+        "week": 1,
+        "date": date_str,
+        "name": name,
+        "vintage": vintage,
+        "badge": "red",
+        "note": "A fine wine.",
+        "window": "2020–2025",
+        "score": "CT90",
+        "location": "Cellar",
+        "urgent": False,
+    }
+
+
+def _suggestion(date_str: str, meal: str, score: str = "good") -> dict:
+    return {
+        "date": date_str,
+        "meal": meal,
+        "pairing": {"score": score, "details": "test"},
+    }
+
+
+# ---------------------------------------------------------------------------
+# TestFindCurrentWeek
+# ---------------------------------------------------------------------------
+
+
+class TestFindCurrentWeek:
+    def test_finds_matching_week(self):
+        from datetime import date, timedelta
+
+        today = date.today()
+        monday = today - timedelta(days=today.weekday())
+        week = _week(monday.strftime("%b %-d, %Y"))
+        result = find_current_week([week], today)
+        assert result is not None
+        assert result["name"] == "Test Wine"
+
+    def test_returns_none_when_no_match(self):
+        from datetime import date
+
+        result = find_current_week([_week("Jan 1, 2020")], date(2026, 6, 15))
+        assert result is None
+
+    def test_empty_list(self):
+        from datetime import date
+
+        assert find_current_week([], date.today()) is None
+
+
+# ---------------------------------------------------------------------------
+# TestFindMealsForDate
+# ---------------------------------------------------------------------------
+
+
+class TestFindMealsForDate:
+    def test_finds_meals(self):
+        suggestions = [
+            _suggestion("2026-04-18", "Pasta"),
+            _suggestion("2026-04-19", "Steak"),
+            _suggestion("2026-04-18", "Salad"),
+        ]
+        result = find_meals_for_date(suggestions, "2026-04-18")
+        assert len(result) == 2
+
+    def test_no_meals(self):
+        result = find_meals_for_date([_suggestion("2026-04-18", "Pasta")], "2026-04-20")
+        assert len(result) == 0
+
+    def test_empty_list(self):
+        assert find_meals_for_date([], "2026-04-18") == []
+
+
+# ---------------------------------------------------------------------------
+# TestBuildDigest
+# ---------------------------------------------------------------------------
+
+
+class TestBuildDigest:
+    def test_has_content_when_pairings_exist(self, tmp_path):
+        from datetime import date, timedelta
+
+        today = date.today()
+        monday = today - timedelta(days=today.weekday())
+
+        plan = {
+            "allWeeks": [_week(monday.strftime("%b %-d, %Y"))],
+        }
+        pairings = {
+            "suggestions": [_suggestion(today.isoformat(), "Chicken dinner")],
+        }
+
+        plan_path = tmp_path / "plan.json"
+        pairing_path = tmp_path / "pairings.json"
+        plan_path.write_text(json.dumps(plan))
+        pairing_path.write_text(json.dumps(pairings))
+
+        digest = build_digest(plan_path, pairing_path)
+        assert digest["has_content"] is True
+        assert len(digest["pairings"]) == 1
+        assert digest["wine"] is not None
+
+    def test_no_content_when_no_pairings(self, tmp_path):
+        from datetime import date, timedelta
+
+        today = date.today()
+        monday = today - timedelta(days=today.weekday())
+
+        plan = {"allWeeks": [_week(monday.strftime("%b %-d, %Y"))]}
+        pairings = {"suggestions": []}
+
+        plan_path = tmp_path / "plan.json"
+        pairing_path = tmp_path / "pairings.json"
+        plan_path.write_text(json.dumps(plan))
+        pairing_path.write_text(json.dumps(pairings))
+
+        digest = build_digest(plan_path, pairing_path)
+        assert digest["has_content"] is False
+
+
+# ---------------------------------------------------------------------------
+# TestFormatDigestHtml
+# ---------------------------------------------------------------------------
+
+
+class TestFormatDigestHtml:
+    def test_contains_wine_name(self):
+        digest = {
+            "date": "2026-04-18",
+            "date_display": "Friday, April 18, 2026",
+            "has_content": True,
+            "wine": {
+                "name": "Dion Vineyard Pinot Noir",
+                "vintage": "2020",
+                "badge": "red",
+                "note": "Great wine.",
+                "window": "2023–2028",
+                "score": "CT90",
+                "location": "Cellar",
+                "urgent": False,
+            },
+            "pairings": [],
+        }
+        html = format_digest_html(digest)
+        assert "Dion Vineyard Pinot Noir" in html
+        assert "2020" in html
+
+    def test_contains_pairing_info(self):
+        digest = {
+            "date": "2026-04-18",
+            "date_display": "Friday, April 18, 2026",
+            "has_content": True,
+            "wine": None,
+            "pairings": [
+                {
+                    "meal": "Grilled chicken",
+                    "pairing": {"score": "good", "details": "matches well"},
+                }
+            ],
+        }
+        html = format_digest_html(digest)
+        assert "Grilled chicken" in html
+        assert "Planned wine pairs well" in html
+
+    def test_sommelier_suggestion_rendered(self):
+        digest = {
+            "date": "2026-04-18",
+            "date_display": "Friday, April 18, 2026",
+            "has_content": True,
+            "wine": None,
+            "pairings": [
+                {
+                    "meal": "Pasta",
+                    "pairing": {"score": "poor", "details": "no match"},
+                    "suggested_bottle": {
+                        "vintage": "2018",
+                        "wine": "Laurène Pinot Noir",
+                        "window": "2022–2031",
+                        "urgency": "in peak window",
+                    },
+                }
+            ],
+        }
+        html = format_digest_html(digest)
+        assert "Sommelier Suggests" in html
+        assert "Laurène Pinot Noir" in html
+
+    def test_urgent_wine_shows_warning(self):
+        digest = {
+            "date": "2026-04-18",
+            "date_display": "Friday, April 18, 2026",
+            "has_content": True,
+            "wine": {
+                "name": "Old Wine",
+                "vintage": "2010",
+                "badge": "red",
+                "note": "",
+                "window": "2015–2020",
+                "score": None,
+                "location": "",
+                "urgent": True,
+            },
+            "pairings": [],
+        }
+        html = format_digest_html(digest)
+        assert "Past peak" in html
+
+    def test_branding_present(self):
+        digest = {
+            "date": "2026-04-18",
+            "date_display": "Friday, April 18, 2026",
+            "has_content": False,
+            "wine": None,
+            "pairings": [],
+        }
+        html = format_digest_html(digest)
+        assert "The Sommelier" in html
+        assert "Drink the right bottles at the right time" in html

--- a/tests/test_send_digest.py
+++ b/tests/test_send_digest.py
@@ -1,0 +1,68 @@
+"""Tests for send_digest.py — email building and idempotency."""
+
+from send_digest import already_sent_today, build_email, mark_sent
+
+
+class TestBuildEmail:
+    def test_subject_includes_wine_name(self):
+        digest = {
+            "wine": {"vintage": "2020", "name": "Dion Vineyard Pinot Noir"},
+        }
+        msg = build_email(digest, "<html>body</html>", "from@test.com", ["to@test.com"])
+        assert "Dion Vineyard Pinot Noir" in msg["Subject"]
+        assert "2020" in msg["Subject"]
+
+    def test_subject_fallback_when_no_wine(self):
+        msg = build_email(
+            {"wine": None}, "<html>body</html>", "from@test.com", ["to@test.com"]
+        )
+        assert "The Sommelier" in msg["Subject"]
+
+    def test_recipients_in_header(self):
+        msg = build_email(
+            {"wine": None},
+            "<html></html>",
+            "from@test.com",
+            ["a@test.com", "b@test.com"],
+        )
+        assert "a@test.com" in msg["To"]
+        assert "b@test.com" in msg["To"]
+
+    def test_html_content_type(self):
+        msg = build_email(
+            {"wine": None}, "<html>test</html>", "from@test.com", ["to@test.com"]
+        )
+        payload = msg.get_payload()
+        assert len(payload) == 1
+        assert payload[0].get_content_type() == "text/html"
+
+
+class TestIdempotency:
+    def test_not_sent_when_no_state_file(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("send_digest.STATE_FILE", tmp_path / "state.txt")
+        assert already_sent_today() is False
+
+    def test_sent_today_returns_true(self, tmp_path, monkeypatch):
+        from datetime import date
+
+        state = tmp_path / "state.txt"
+        state.write_text(date.today().isoformat())
+        monkeypatch.setattr("send_digest.STATE_FILE", state)
+        assert already_sent_today() is True
+
+    def test_sent_yesterday_returns_false(self, tmp_path, monkeypatch):
+        from datetime import date, timedelta
+
+        state = tmp_path / "state.txt"
+        state.write_text((date.today() - timedelta(days=1)).isoformat())
+        monkeypatch.setattr("send_digest.STATE_FILE", state)
+        assert already_sent_today() is False
+
+    def test_mark_sent_creates_file(self, tmp_path, monkeypatch):
+        from datetime import date
+
+        state = tmp_path / "state.txt"
+        monkeypatch.setattr("send_digest.STATE_FILE", state)
+        mark_sent()
+        assert state.exists()
+        assert state.read_text() == date.today().isoformat()

--- a/tests/test_send_digest.py
+++ b/tests/test_send_digest.py
@@ -43,26 +43,23 @@ class TestIdempotency:
         assert already_sent_today() is False
 
     def test_sent_today_returns_true(self, tmp_path, monkeypatch):
-        from datetime import date
-
+        monkeypatch.setattr("send_digest._today_local", lambda: "2026-04-18")
         state = tmp_path / "state.txt"
-        state.write_text(date.today().isoformat())
+        state.write_text("2026-04-18")
         monkeypatch.setattr("send_digest.STATE_FILE", state)
         assert already_sent_today() is True
 
     def test_sent_yesterday_returns_false(self, tmp_path, monkeypatch):
-        from datetime import date, timedelta
-
+        monkeypatch.setattr("send_digest._today_local", lambda: "2026-04-18")
         state = tmp_path / "state.txt"
-        state.write_text((date.today() - timedelta(days=1)).isoformat())
+        state.write_text("2026-04-17")
         monkeypatch.setattr("send_digest.STATE_FILE", state)
         assert already_sent_today() is False
 
     def test_mark_sent_creates_file(self, tmp_path, monkeypatch):
-        from datetime import date
-
+        monkeypatch.setattr("send_digest._today_local", lambda: "2026-04-18")
         state = tmp_path / "state.txt"
         monkeypatch.setattr("send_digest.STATE_FILE", state)
         mark_sent()
         assert state.exists()
-        assert state.read_text() == date.today().isoformat()
+        assert state.read_text() == "2026-04-18"


### PR DESCRIPTION
## Summary
- Generates a branded HTML digest email showing tonight's planned wine and food-pairing details
- Sends via Gmail SMTP at 8am through supercronic with idempotent delivery tracking
- Includes `send_digest.sh` wrapper to resolve 1Password SMTP credentials for cron context
- Deduplicates `find_current_week()` into `wine_utils.py` (shared by `thisweek.py` and `generate_digest.py`)
- Only sends when there's a menu entry for today — a "go pull this wine" reminder, not a daily newsletter

## Test plan
- [x] `python3 -m pytest tests/ -v` — all 268 tests pass
- [x] `pre-commit run --all-files` — all hooks pass
- [ ] Verify digest generation with live data (`python3 scripts/generate_digest.py`)
- [ ] Verify email send with `--dry-run` flag
- [ ] Verify idempotent send (second run same day skips)

🤖 Generated with [Claude Code](https://claude.com/claude-code)