### PR TITLE
Show pairing confidence level in UI (#45)

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -171,9 +171,15 @@ function renderPairingsHtml(pairings) {
     } else {
       cls = 'partial'; icon = '—'; detail = 'enjoy the planned wine';
     }
+    var conf = s.pairing.confidence;
+    var confBadge = '';
+    if (conf === 'high' || conf === 'medium' || conf === 'low') {
+      var label = conf === 'medium' ? 'med' : conf;
+      confBadge = ' <span class="confidence-badge ' + conf + '">' + label + '</span>';
+    }
     html += '<div class="pairing-row ' + cls + '">' +
       '<span class="pairing-icon">' + icon + '</span>' +
-      '<div><span class="pairing-meal">' + p.dayName + ': ' + s.meal + '</span>' +
+      '<div><span class="pairing-meal">' + p.dayName + ': ' + s.meal + confBadge + '</span>' +
       (detail ? '<div class="pairing-detail">' + detail + '</div>' : '') +
       '</div></div>';
   }

--- a/site/index.html
+++ b/site/index.html
@@ -179,7 +179,7 @@ function renderPairingsHtml(pairings) {
     }
     html += '<div class="pairing-row ' + cls + '">' +
       '<span class="pairing-icon">' + icon + '</span>' +
-      '<div><span class="pairing-meal">' + p.dayName + ': ' + s.meal + confBadge + '</span>' +
+      '<div><span class="pairing-meal">' + p.dayName + ': ' + s.meal + '</span>' + confBadge +
       (detail ? '<div class="pairing-detail">' + detail + '</div>' : '') +
       '</div></div>';
   }

--- a/site/style.css
+++ b/site/style.css
@@ -886,6 +886,25 @@ footer strong { color: var(--text); font-weight: 600; }
   font-weight: 600;
 }
 
+.confidence-badge {
+  display: inline-block;
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  padding: 1px 6px;
+  border-radius: 3px;
+  margin-left: 6px;
+  vertical-align: middle;
+}
+
+.confidence-badge.high { background: #3b4f1e; color: #e9f3db; }
+.confidence-badge.medium { background: #b8a468; color: #fff; }
+.confidence-badge.low { background: var(--border); color: var(--muted); }
+.pairing-row.sommelier .confidence-badge.high { background: var(--accent); color: #fff; }
+.pairing-row.sommelier .confidence-badge.medium { background: #6d91b3; color: #fff; }
+.pairing-row.partial .confidence-badge.low { background: var(--border-strong); color: #8e8c84; }
+
 .pairing-row .pairing-detail {
   font-size: 13px;
   opacity: 0.85;


### PR DESCRIPTION
## Summary
- Add inline pill badges (high/med/low) next to meal names in the pairings view
- Contextual badge coloring adapts to parent row type: green for good pairings, blue for sommelier picks, muted for partial matches
- Compact 10px uppercase design that integrates with existing pairing row layout

## Test plan
- [ ] Verify badges render for high, medium, and low confidence pairings
- [ ] Verify badge colors match their parent row type (good=green, sommelier=blue, partial=gray)
- [ ] Verify no badge appears when confidence is missing or undefined
- [ ] Check mobile layout — badges should stay inline without wrapping issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)