### PR TITLE
Pin Claude Code CLI to v2.1.114 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Claude Code CLI
-# hadolint ignore=DL3016
-RUN npm install -g @anthropic-ai/claude-code
+RUN npm install -g @anthropic-ai/claude-code@2.1.114
 
 # Install 1Password CLI (multi-arch: works on both amd64 and arm64)
 RUN ARCH=$(dpkg --print-architecture) \


### PR DESCRIPTION
## Summary
- Pin `@anthropic-ai/claude-code` to v2.1.114 to prevent Docker rebuilds from silently picking up breaking CLI changes (fixes #36)
- Remove hadolint DL3016 ignore comment since the version is now pinned

## Test plan
- [x] All pre-commit hooks pass (including hadolint)
- [x] Version pin matches latest release

🤖 Generated with [Claude Code](https://claude.com/claude-code)