### PR TITLE
v3.0.1 — Quick Fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -210,6 +210,7 @@ Implemented in `scripts/generate_plan.py`:
 - Shell scripts must have executable permission in git: `chmod +x *.sh && git add`
 - Docker volume mount requires `git config --global --add safe.directory /app` (handled in entrypoint)
 - Pre-commit hooks (ruff format) may modify files on first commit — re-stage and commit again
+- Claude Code CLI is version-pinned in the Dockerfile — update the pin deliberately when upgrading
 
 ## Important Conventions
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Claude Code CLI
-# hadolint ignore=DL3016
-RUN npm install -g @anthropic-ai/claude-code
+RUN npm install -g @anthropic-ai/claude-code@2.1.114
 
 # Install 1Password CLI (multi-arch: works on both amd64 and arm64)
 RUN ARCH=$(dpkg --print-architecture) \

--- a/pipeline.sh
+++ b/pipeline.sh
@@ -119,7 +119,7 @@ python3 scripts/generate_plan.py data/inventory.json data/plan.json || { log "ER
 # --- GENERATE NOTES (LLM — Claude Code CLI, augmented with CT notes) ---
 if command -v claude &> /dev/null; then
   log "==> Generating tasting notes (Claude)..."
-  python3 scripts/generate_notes.py data/plan.json data/notes.tsv data/foodtags.tsv data/community_notes.json || log "WARNING: Note generation failed — plan will have empty notes"
+  python3 scripts/generate_notes.py data/plan.json data/notes.tsv data/foodtags.tsv data/community_notes.json data/inventory.json || log "WARNING: Note generation failed — plan will have empty notes"
 else
   log "    Skipping note generation — claude CLI not available"
 fi

--- a/scripts/generate_notes.py
+++ b/scripts/generate_notes.py
@@ -7,7 +7,7 @@ CT tasting notes, community tasting notes, and food pairing data.
 
 Requires CLAUDE_CODE_OAUTH_TOKEN in the environment.
 
-Usage: generate_notes.py <plan.json> [notes.tsv] [foodtags.tsv] [community_notes.json]
+Usage: generate_notes.py <plan.json> [notes.tsv] [foodtags.tsv] [community_notes.json] [inventory.json]
 """
 
 import csv
@@ -58,19 +58,18 @@ def parse_ct_foodtags(foodtags_path: str) -> dict[str, list[str]]:
     return tags_by_wine
 
 
-def load_inventory_index(plan_data: dict) -> dict[str, str]:
-    """Build a rough vintage+name → iWine index from plan entries (if available)."""
-    # plan entries don't have iWine, but we can match via inventory.json if present
+def load_inventory_index(inv_path: str | None) -> dict[str, str]:
+    """Build a rough vintage+name → iWine index from inventory.json (if available)."""
     index = {}
-    inv_path = Path("data/inventory.json")
-    if inv_path.exists():
-        try:
-            inventory = json.loads(inv_path.read_text())
-            for wine in inventory:
-                key = f"{wine.get('Vintage', '')}|{wine.get('Wine', '')}".lower()
-                index[key] = str(wine.get("iWine", ""))
-        except Exception:
-            pass
+    if not inv_path:
+        return index
+    try:
+        inventory = json.loads(Path(inv_path).read_text(encoding="utf-8"))
+        for wine in inventory:
+            key = f"{wine.get('Vintage', '')}|{wine.get('Wine', '')}".lower()
+            index[key] = str(wine.get("iWine", ""))
+    except (json.JSONDecodeError, OSError, UnicodeDecodeError) as e:
+        print(f"WARNING: Could not load inventory index: {e}", file=sys.stderr)
     return index
 
 
@@ -170,6 +169,7 @@ def generate_notes(
     notes_path: str | None = None,
     foodtags_path: str | None = None,
     community_notes_path: str | None = None,
+    inventory_path: str | None = None,
 ) -> None:
     """Generate notes for plan entries with empty notes."""
     plan_data = json.loads(Path(plan_path).read_text())
@@ -179,7 +179,7 @@ def generate_notes(
     ct_notes = parse_ct_notes(notes_path) if notes_path else {}
     ct_foodtags = parse_ct_foodtags(foodtags_path) if foodtags_path else {}
     community_notes = load_community_notes(community_notes_path)
-    inv_index = load_inventory_index(plan_data)
+    inv_index = load_inventory_index(inventory_path)
 
     if ct_notes:
         print(f"  Loaded {sum(len(v) for v in ct_notes.values())} CellarTracker notes")
@@ -202,6 +202,7 @@ def generate_notes(
     print(f"Generating notes for {len(needs_notes)} entries...")
 
     # Process in batches
+    week_map = {w["week"]: w for w in all_weeks}
     notes_generated = 0
     for i in range(0, len(needs_notes), BATCH_SIZE):
         batch = needs_notes[i : i + BATCH_SIZE]
@@ -215,12 +216,17 @@ def generate_notes(
 
         notes = extract_json(response)
         for week_str, note in notes.items():
-            week_num = int(week_str)
-            for w in all_weeks:
-                if w["week"] == week_num:
-                    w["note"] = note
-                    notes_generated += 1
-                    break
+            try:
+                week_num = int(week_str)
+            except ValueError:
+                print(
+                    f"WARNING: Skipping non-numeric week key: {week_str!r}",
+                    file=sys.stderr,
+                )
+                continue
+            if week_num in week_map:
+                week_map[week_num]["note"] = note
+                notes_generated += 1
 
     Path(plan_path).write_text(
         json.dumps(plan_data, indent=2, ensure_ascii=False), encoding="utf-8"
@@ -231,7 +237,7 @@ def generate_notes(
 if __name__ == "__main__":
     if len(sys.argv) < 2:
         print(
-            "Usage: generate_notes.py <plan.json> [notes.tsv] [foodtags.tsv] [community_notes.json]",
+            "Usage: generate_notes.py <plan.json> [notes.tsv] [foodtags.tsv] [community_notes.json] [inventory.json]",
             file=sys.stderr,
         )
         sys.exit(1)
@@ -240,4 +246,5 @@ if __name__ == "__main__":
         sys.argv[2] if len(sys.argv) > 2 else None,
         sys.argv[3] if len(sys.argv) > 3 else None,
         sys.argv[4] if len(sys.argv) > 4 else None,
+        sys.argv[5] if len(sys.argv) > 5 else None,
     )

--- a/site/index.html
+++ b/site/index.html
@@ -199,11 +199,24 @@ function renderCalendar() {
     if (!byYear[yr][mo]) byYear[yr][mo] = [];
     byYear[yr][mo].push(w);
   });
+  // Build a map of which plan years (1, 2) appear in each calendar year
+  const planYearsByCalYear = {};
+  allWeeks.forEach(function(w) {
+    const calYr = new Date(w.date).getFullYear();
+    if (!planYearsByCalYear[calYr]) planYearsByCalYear[calYr] = new Set();
+    planYearsByCalYear[calYr].add(w.year);
+  });
   Object.keys(byYear).sort().forEach(function(yr) {
     const yearBlock = document.createElement('div');
     const yh = document.createElement('div');
     yh.className = 'cal-year-header';
-    const subText = yr == 2026 ? 'Year 1 begins' : yr == 2027 ? 'Year 1 ends · Year 2 begins' : 'Year 2 ends';
+    const py = planYearsByCalYear[yr] || new Set();
+    const parts = [];
+    if (py.has(1) && py.has(2)) { parts.push('Year 1 ends', 'Year 2 begins'); }
+    else if (py.has(1)) { parts.push('Year 1'); }
+    else if (py.has(2)) { parts.push('Year 2'); }
+    const subText = parts.join(' \u00b7 ');
+    // yr and subText are derived from trusted plan data (integers and static strings)
     yh.innerHTML = yr + ' <span class="cal-year-sub">' + subText + '</span>';
     yearBlock.appendChild(yh);
     const grid = document.createElement('div');
@@ -226,7 +239,7 @@ function renderCalendar() {
         const flags = [];
         if (w.urgent)    flags.push('<span class="cal-flag urgent">⚠ Urgent</span>');
         if (w.evolution) flags.push('<span class="cal-flag evolution">◉ Evolution</span>');
-        if (w.occasion)  flags.push('<span class="cal-flag occasion">' + occasionIcon(w.occasion) + ' ' + w.occasion + '</span>');
+        if (w.occasion)  flags.push('<span class="cal-flag occasion">' + occasionIcon(w.occasion) + ' ' + escapeHtml(w.occasion) + '</span>');
         else if (w.special && !w.evolution) flags.push('<span class="cal-flag special">◆ Special</span>');
         const entry = document.createElement('div');
         entry.className = 'cal-entry';
@@ -235,7 +248,7 @@ function renderCalendar() {
           '<div class="cal-entry-body">' +
             '<div class="cal-entry-date">' + dayStr + ' &nbsp;·&nbsp; ' + label + '</div>' +
             '<div class="cal-entry-name"><span class="cal-entry-vintage">' + w.vintage + '</span> ' + w.name + '</div>' +
-            '<div class="cal-entry-sub">' + w.appellation.split(' · ')[0] + '</div>' +
+            '<div class="cal-entry-sub">' + escapeHtml(w.appellation.split(' · ')[0]) + '</div>' +
             (flags.length ? '<div class="cal-entry-flags">' + flags.join('') + '</div>' : '') +
           '</div>';
         var calPairings = getPairingsForWeek(w.date);
@@ -385,17 +398,17 @@ function renderPlan() {
         let html = '<div class="card-top"><span class="week-num">Week ' + w.week + '</span><span class="week-date">' + w.date + '</span></div>';
         html += '<div class="badge badge-' + w.badge + '">' + wineIcon(w.badge, 14) + label + '</div>';
         html += '<div class="wine-name"><span class="wine-vintage">' + w.vintage + '</span> ' + w.name + '</div>';
-        html += '<div class="wine-appellation">' + w.appellation + '</div>';
+        html += '<div class="wine-appellation">' + escapeHtml(w.appellation) + '</div>';
         if (w.window || w.score) {
           html += '<div class="wine-meta">';
           if (w.window) html += '<div class="meta-item">Window <span>' + w.window + '</span></div>';
           if (w.score)  html += '<div class="meta-item">Score <span>' + w.score + '</span></div>';
           html += '</div>';
         }
-        if (w.occasion)  html += '<div class="occasion-tag">' + occasionIcon(w.occasion) + ' ' + w.occasion + '</div>';
+        if (w.occasion)  html += '<div class="occasion-tag">' + occasionIcon(w.occasion) + ' ' + escapeHtml(w.occasion) + '</div>';
         if (w.urgent)    html += '<div class="urgent-flag">Drink now — urgent</div>';
         if (w.evolution) html += '<div class="evolution-flag">Evolution track</div>';
-        html += '<div class="note-text">' + w.note + '</div>';
+        html += '<div class="note-text">' + escapeHtml(w.note) + '</div>';
         var pairings = getPairingsForWeek(w.date);
         html += renderPairingsHtml(pairings);
         card.innerHTML = html;


### PR DESCRIPTION
## Summary

Small, high-impact fixes that improve correctness and robustness across error handling, XSS prevention, and build reproducibility.

## Issues Resolved

- #43 — Fix silent error swallowing in load_inventory_index() (PR #51)
- #44 — Fix unhandled ValueError crash when Claude returns non-numeric week keys (PR #51)
- #37 — Remove hardcoded inventory path in generate_notes.py (PR #51)
- #35 — Escape LLM-generated content in innerHTML assignments (PR #52)
- #34 — Fix hardcoded year labels in calendar view (PR #52)
- #36 — Pin Claude Code CLI version in Dockerfile (PR #54)

## Test Plan

- [x] All issue PRs reviewed and merged
- [x] `pre-commit run --all-files` passes
- [x] `python3 -m pytest tests/ -v` passes (289 tests)
- [ ] Docker build succeeds: `docker compose build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)