### PR TITLE
Address pre-merge code-review findings on Claude Code harness

### DIFF
--- a/.claude/commands/new-issue.md
+++ b/.claude/commands/new-issue.md
@@ -38,6 +38,12 @@ Wait for confirmation before proceeding.
 
 ### Step 3: PM-Driven Scope Definition
 
+> **Note:** The role-based agents below (`senior-product-manager`,
+> `senior-architect`, `senior-test-engineer`, `technical-documentation-writer`)
+> come from an installed agent plugin and are not defined locally in
+> `.claude/agents/`. If they are unavailable, fall back to the generic `Agent`
+> tool with a role-specific prompt.
+
 Launch the **senior-product-manager** agent with:
 
 - The user's problem statement
@@ -120,10 +126,15 @@ create a separate issue for it?"
 
 ### Step 7: Create the Issue
 
-Once the user approves, create the issue on GitHub:
+Once the user approves, create the issue on GitHub. Pass each approved label
+with a separate `--label` flag, and include `--milestone` if one was selected:
 
 ```bash
-gh issue create --title "Issue title" --body "$(cat <<'EOF'
+gh issue create \
+  --title "Issue title" \
+  --label "LABEL_1" --label "LABEL_2" \
+  --milestone "MILESTONE_NAME" \
+  --body "$(cat <<'EOF'
 ## Problem
 
 Description of the problem or need.
@@ -152,6 +163,9 @@ High-level approach.
 EOF
 )"
 ```
+
+Omit `--milestone` if none was chosen, and omit `--label` flags if no labels
+were approved.
 
 After creation, display the issue URL and number.
 

--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -90,12 +90,15 @@ When the user runs `/release`, execute this comprehensive release workflow:
    - Major technical changes
    - Test coverage changes
 
-3. **Present to User for Review**
-   - Show the generated release notes in the conversation
+3. **Save and Present to User for Review**
+   - Write the generated notes to `RELEASE_NOTES.md` at the repo root.
+   - Show the generated release notes in the conversation.
    - Ask: "Review the release notes above. Reply with 'approve' to continue,
      'edit' to modify, or provide specific changes."
-   - If user says 'edit', open in VS Code with: `code --wait [file]`
-   - Wait for user approval
+   - If the user says 'edit', open `RELEASE_NOTES.md` in their editor
+     (try `${EDITOR:-code} --wait RELEASE_NOTES.md`; fall back to instructing
+     the user to edit the file manually if no editor is available).
+   - Wait for user approval.
 
 ## Phase 3: Execute Release
 
@@ -143,10 +146,14 @@ When the user runs `/release`, execute this comprehensive release workflow:
 
 5. **Create GitHub Release**
 
+   Use the curated `RELEASE_NOTES.md` produced in Phase 2 — do **not** pass
+   `--generate-notes`, which would discard them in favor of GitHub's
+   auto-generated commit summary.
+
    ```bash
    gh release create v[VERSION] \
      --title "The Sommelier v[VERSION]" \
-     --generate-notes
+     --notes-file RELEASE_NOTES.md
    ```
 
 6. **Provide Deployment Instructions**

--- a/.claude/commands/simplify.md
+++ b/.claude/commands/simplify.md
@@ -1,3 +1,7 @@
+---
+description: Review recently modified code for clarity, reuse, and standards alignment without changing behavior
+---
+
 # Simplify
 
 Review the recently modified code for opportunities to simplify, improve clarity, reduce redundancy,
@@ -5,4 +9,6 @@ and align with project coding standards — without changing any behavior. Focus
 in the current session unless instructed otherwise.
 
 Use the Agent tool with `subagent_type: "code-simplifier:code-simplifier"` to perform the review
-and apply refinements.
+and apply refinements. The `code-simplifier` agent comes from an installed plugin and is not defined
+locally in `.claude/agents/` — if it is unavailable, fall back to the generic `Agent` tool with a
+prompt that asks for the same review.

--- a/.claude/commands/start-issue.md
+++ b/.claude/commands/start-issue.md
@@ -16,6 +16,12 @@ description: Start work on a GitHub issue within a milestone workflow
 | Senior Test Engineer | `senior-test-engineer` | `sonnet` | Test strategy and writing |
 | Technical Documentation Writer | `technical-documentation-writer` | `haiku` | Docs updates |
 
+> **Note:** Only `Explore`, `Plan`, `pipeline-reviewer`, and `site-reviewer` are
+> defined locally in `.claude/agents/`. The role-based agents above
+> (`software-developer`, `senior-architect`, etc.) come from an installed agent
+> plugin. If they are unavailable, fall back to the generic `Agent` tool with a
+> role-specific prompt.
+
 **Always invoke:** Explore (Step 5), senior-product-manager (Step 6), senior-architect (Step 7.3).
 **Always invoke for code changes:** software-developer, senior-test-engineer.
 **Skip** docs agent for internal refactoring; test agent for docs-only changes.
@@ -35,7 +41,8 @@ gh issue view ISSUE_NUMBER --json number,title,body,milestone,labels
 1. `git branch --show-current` — must match `milestone/*`
    - Zero milestone branches: stop, tell user to run `/start-milestone` first
    - Multiple: stop, ask which one
-2. **Branch naming** — `bug/` for bug label, `feature/` for enhancement, `issue/` for all others. Confirm name with user before creating.
+2. **Ensure clean working tree** — run `git status --porcelain`. If any output appears, stop and ask the user to commit or stash before proceeding.
+3. **Branch naming** — `bug/` for bug label, `feature/` for enhancement, `issue/` for all others. Confirm name with user before creating.
 
 ### Step 4: Create Issue Branch
 
@@ -101,11 +108,10 @@ Use EnterPlanMode. While planning:
 ```text
 Implementation complete for issue #ISSUE_NUMBER. Next steps:
 1. /simplify        — Review changed code (optional)
-2. /review-pr       — Multi-agent local review (recommended before push)
-3. /commit          — Commit your changes
-4. /commit-push-pr  — Push and create a PR targeting `MILESTONE_BRANCH`
-                      Include "Closes #ISSUE_NUMBER" in the PR body.
-5. /finish-issue    — Squash-merge, close the issue, return to milestone branch
+2. /security-review — Audit changes before push
+3. Commit your changes manually (`git commit`) and push the branch.
+   Open a PR targeting `MILESTONE_BRANCH` and include "Closes #ISSUE_NUMBER" in the body.
+4. /finish-issue    — Squash-merge, close the issue, return to milestone branch
 ```
 
 > Do NOT run any of these steps automatically.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,7 +127,7 @@ Tests require `pytest` (install via `pip install pytest`). The `conftest.py` at 
 
 ```bash
 ruff check scripts/ && ruff format --check scripts/  # check only
-ruff format scripts/                                   # auto-fix
+ruff check --fix scripts/ && ruff format scripts/    # auto-fix lint + formatting
 ```
 
 ## Docker Deployment

--- a/scripts/pairing.py
+++ b/scripts/pairing.py
@@ -172,9 +172,16 @@ def score_enriched_pairing(wine_name: str, enriched: dict) -> dict | None:
     signals = 0
     suggested_styles: list[str] = []
 
-    def _check(rules: dict[str, list[str]], value: str | None) -> None:
+    def _check(rules: dict[str, list[str]], value: object) -> None:
         nonlocal matches, mismatches, signals
-        if not value or value not in rules:
+        # The LLM enrichment occasionally returns a list for fields documented
+        # as scalars (e.g. protein=["salmon", "shrimp"] for a multi-protein dish).
+        # Pick the first element that's a known rule key.
+        if isinstance(value, list):
+            value = next(
+                (v for v in value if isinstance(v, str) and v in rules), None
+            )
+        if not isinstance(value, str) or value not in rules:
             return
         signals += 1
         preferred = rules[value]

--- a/tests/test_pairing_enriched.py
+++ b/tests/test_pairing_enriched.py
@@ -103,6 +103,32 @@ class TestScoreEnrichedPairing:
         assert "suggested_styles" in result
         assert len(result["suggested_styles"]) > 0
 
+    def test_list_valued_protein_does_not_crash(self):
+        # The LLM occasionally returns a list for a scalar field when the dish
+        # has multiple proteins. Must not raise TypeError on dict membership.
+        enriched = {"protein": ["salmon", "shrimp"]}
+        result = score_enriched_pairing("pinot noir", enriched)
+        assert result is not None
+        assert result["score"] == "good"
+
+    def test_list_valued_protein_first_known_wins(self):
+        # Unknown leading entries are skipped; first known key drives scoring.
+        enriched = {"protein": ["unknownfish", "beef"]}
+        result = score_enriched_pairing("cabernet sauvignon", enriched)
+        assert result is not None
+        assert result["score"] == "good"
+
+    def test_list_valued_cuisine_does_not_crash(self):
+        enriched = {"cuisine": ["italian", "american"], "richness": "medium"}
+        result = score_enriched_pairing("sangiovese chianti", enriched)
+        assert result is not None
+
+    def test_list_with_no_known_keys_skipped(self):
+        # A list of unrecognized values should produce no signal, not crash.
+        enriched = {"protein": ["unobtanium"]}
+        result = score_enriched_pairing("any wine", enriched)
+        assert result is None
+
 
 class TestBuildEnrichedIndex:
     def test_builds_index_from_enriched_list(self):


### PR DESCRIPTION
- start-issue.md: restore the clean-working-tree check that the prior
  version dropped; flag role-based agents as plugin-provided (not local);
  remove handoff references to commands that don't exist in this repo
  (/review-pr, /commit, /commit-push-pr).
- new-issue.md: flag role-based agents as plugin-provided; pass --label
  and --milestone to `gh issue create` so PM-approved metadata actually
  lands on the issue.
- release.md: write generated release notes to RELEASE_NOTES.md and pass
  them to `gh release create` via --notes-file; previously --generate-notes
  silently discarded the curated notes. Use $EDITOR for the edit fallback
  so this doesn't assume `code` is on PATH.
- simplify.md: add frontmatter so the command renders consistently in
  /help; flag the code-simplifier agent as plugin-provided.
- CLAUDE.md: linting `auto-fix` recipe now actually fixes lints
  (`ruff check --fix`) in addition to formatting.