### PR TITLE
Fix #67: coerce scalar enrichment fields at write time so bad shapes never enter cache

### DIFF
--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,6 +1,7 @@
 {
   "include": ["scripts"],
   "exclude": ["tests"],
+  "extraPaths": ["scripts"],
   "typeCheckingMode": "basic",
   "pythonVersion": "3.12",
   "reportMissingImports": true,

--- a/scripts/enrich_menu.py
+++ b/scripts/enrich_menu.py
@@ -30,6 +30,24 @@ ENRICHED_FIELDS = [
     "pairing_priorities",
 ]
 
+# Fields documented as scalar strings in the enrichment schema.
+# Claude occasionally returns a list for these; we normalize before caching.
+SCALAR_FIELDS: frozenset[str] = frozenset(
+    {
+        "protein",
+        "cut",
+        "preparation",
+        "sauce",
+        "sauce_intensity",
+        "cuisine",
+        "richness",
+        "acidity",
+        "sweetness",
+        "spice_heat",
+    }
+)
+# NOTE: sides, dominant_flavor_axis, pairing_priorities are intentional arrays — omit them.
+
 
 def text_hash(text: str) -> str:
     """Stable hash of menu text for cache keying."""
@@ -64,6 +82,7 @@ Rules:
 - Omit fields rather than guess — only include what's clearly implied by the menu text
 - For simple entries like "Leftovers" or "Pizza night", include what you can infer
 - Be concise in string values
+- Scalar fields (protein, cut, preparation, sauce, sauce_intensity, cuisine, richness, acidity, sweetness, spice_heat) must be a single string, not an array
 
 Return ONLY a JSON object mapping entry index to its features, like:
 {{"0": {{"protein": "pork", "preparation": "grilled", ...}}, "1": {{...}}}}
@@ -82,6 +101,46 @@ def load_cache(cache_path: Path) -> dict[str, dict]:
     return {}
 
 
+def _normalize_enriched(enriched: dict) -> dict:
+    """Coerce scalar fields to strings before caching.
+
+    Claude occasionally returns a list (e.g. protein=["salmon", "shrimp"]) or a
+    non-string scalar (e.g. richness=3) for fields documented as scalar strings.
+    This normalizes them so bad shapes never enter the cache.
+
+    - list  → first string element; if none, field is omitted
+    - non-string scalar (int, float, bool, …) → str(val)
+    - correct string → unchanged
+    - array fields (sides, dominant_flavor_axis, pairing_priorities) → untouched
+    """
+    result = dict(enriched)  # shallow copy — never mutate the caller's dict
+    for field in SCALAR_FIELDS:
+        val = result.get(field)
+        if val is None:
+            continue
+        if isinstance(val, list):
+            first = next((v for v in val if isinstance(v, str)), None)
+            if first is not None:
+                result[field] = first
+                print(
+                    f"WARNING: enrichment field '{field}' was a list — coerced to scalar",
+                    file=sys.stderr,
+                )
+            else:
+                del result[field]
+                print(
+                    f"WARNING: enrichment field '{field}' had no string elements — field omitted",
+                    file=sys.stderr,
+                )
+        elif not isinstance(val, str):
+            result[field] = str(val)
+            print(
+                f"WARNING: enrichment field '{field}' was {type(val).__name__} — coerced to string",
+                file=sys.stderr,
+            )
+    return result
+
+
 def enrich_menu(
     menu_path: Path, cache_path: Path, output_path: Path | None = None
 ) -> list[dict]:
@@ -96,8 +155,12 @@ def enrich_menu(
     for entry in menu:
         h = text_hash(entry["meal"])
         if h in cache:
+            normalized = _normalize_enriched(cache[h])
+            cache[h] = (
+                normalized  # update in-memory cache so _write_files repairs the file
+            )
             results.append(
-                {"raw": entry["meal"], "hash": h, "enriched": cache[h], **entry}
+                {"raw": entry["meal"], "hash": h, "enriched": normalized, **entry}
             )
         else:
             results.append({"raw": entry["meal"], "hash": h, "enriched": None, **entry})
@@ -128,6 +191,7 @@ def enrich_menu(
     for batch_idx, (result_idx, entry) in enumerate(to_enrich):
         enriched = enrichments.get(str(batch_idx))
         if enriched and isinstance(enriched, dict):
+            enriched = _normalize_enriched(enriched)
             h = results[result_idx]["hash"]
             results[result_idx]["enriched"] = enriched
             cache[h] = enriched

--- a/scripts/pairing.py
+++ b/scripts/pairing.py
@@ -178,9 +178,7 @@ def score_enriched_pairing(wine_name: str, enriched: dict) -> dict | None:
         # as scalars (e.g. protein=["salmon", "shrimp"] for a multi-protein dish).
         # Pick the first element that's a known rule key.
         if isinstance(value, list):
-            value = next(
-                (v for v in value if isinstance(v, str) and v in rules), None
-            )
+            value = next((v for v in value if isinstance(v, str) and v in rules), None)
         if not isinstance(value, str) or value not in rules:
             return
         signals += 1

--- a/tests/test_enrich_menu.py
+++ b/tests/test_enrich_menu.py
@@ -1,9 +1,15 @@
 """Tests for enrich_menu.py — prompt building, JSON extraction, cache."""
 
 import json
+from unittest.mock import patch
 
-
-from enrich_menu import build_enrichment_prompt, load_cache, text_hash
+from enrich_menu import (
+    _normalize_enriched,
+    build_enrichment_prompt,
+    enrich_menu,
+    load_cache,
+    text_hash,
+)
 from wine_utils import extract_json
 
 
@@ -86,3 +92,157 @@ class TestLoadCache:
         p = tmp_path / "bad.json"
         p.write_text("{bad")
         assert load_cache(p) == {}
+
+
+class TestNormalizeEnriched:
+    """Unit tests for _normalize_enriched — scalar-field coercion before caching."""
+
+    def test_scalar_list_coerced_to_first_string(self):
+        result = _normalize_enriched({"protein": ["chicken", "shrimp"]})
+        assert result["protein"] == "chicken"
+
+    def test_scalar_single_element_list_coerced(self):
+        result = _normalize_enriched({"richness": ["medium"]})
+        assert result["richness"] == "medium"
+
+    def test_all_ten_scalar_fields_coerced(self):
+        scalar_fields = [
+            "protein",
+            "cut",
+            "preparation",
+            "sauce",
+            "sauce_intensity",
+            "cuisine",
+            "richness",
+            "acidity",
+            "sweetness",
+            "spice_heat",
+        ]
+        payload = {f: ["x"] for f in scalar_fields}
+        result = _normalize_enriched(payload)
+        for field in scalar_fields:
+            assert result[field] == "x", (
+                f"Expected '{field}' to be coerced to 'x', got {result[field]!r}"
+            )
+
+    def test_scalar_already_string_unchanged(self):
+        result = _normalize_enriched({"protein": "beef"})
+        assert result["protein"] == "beef"
+
+    def test_scalar_int_coerced_to_string(self):
+        result = _normalize_enriched({"richness": 3})
+        assert result["richness"] == "3"
+
+    def test_scalar_float_coerced_to_string(self):
+        result = _normalize_enriched({"acidity": 0.7})
+        assert result["acidity"] == "0.7"
+
+    def test_scalar_none_unchanged(self):
+        result = _normalize_enriched({"protein": None})
+        assert "protein" in result
+        assert result["protein"] is None
+
+    def test_scalar_empty_list_field_omitted(self):
+        result = _normalize_enriched({"protein": []})
+        assert "protein" not in result
+
+    def test_scalar_list_no_string_elements_field_omitted(self):
+        # A list of ints contains no string elements, so the field should be omitted.
+        result = _normalize_enriched({"protein": [42, 99]})
+        assert "protein" not in result
+
+    def test_array_field_sides_untouched(self):
+        result = _normalize_enriched({"sides": ["potatoes", "kale"]})
+        assert result["sides"] == ["potatoes", "kale"]
+
+    def test_array_field_dominant_flavor_axis_untouched(self):
+        # Single-element list on an array field must NOT be coerced to a bare string.
+        result = _normalize_enriched({"dominant_flavor_axis": ["savory"]})
+        assert result["dominant_flavor_axis"] == ["savory"]
+
+    def test_array_field_pairing_priorities_untouched(self):
+        result = _normalize_enriched({"pairing_priorities": ["match acidity"]})
+        assert result["pairing_priorities"] == ["match acidity"]
+
+    def test_array_single_element_not_coerced(self):
+        # Critical boundary: single-element array fields must never be coerced to strings.
+        result = _normalize_enriched({"sides": ["potatoes"]})
+        assert result["sides"] == ["potatoes"]
+
+    def test_mixed_realistic_payload(self):
+        payload = {
+            "protein": ["pork"],
+            "preparation": ["grilled"],
+            "richness": "medium",
+            "sides": ["fingerlings", "kale"],
+            "dominant_flavor_axis": ["savory", "smoky"],
+            "pairing_priorities": ["match weight"],
+        }
+        result = _normalize_enriched(payload)
+        assert result["protein"] == "pork"
+        assert result["preparation"] == "grilled"
+        assert result["richness"] == "medium"
+        assert result["sides"] == ["fingerlings", "kale"]
+        assert result["dominant_flavor_axis"] == ["savory", "smoky"]
+        assert result["pairing_priorities"] == ["match weight"]
+
+    def test_empty_dict_returns_empty_dict(self):
+        assert _normalize_enriched({}) == {}
+
+    def test_unknown_field_untouched(self):
+        # Unrecognized fields that aren't in SCALAR_FIELDS pass through unchanged.
+        result = _normalize_enriched({"future_field": ["val"]})
+        assert result["future_field"] == ["val"]
+
+    def test_returns_new_dict_not_mutates_input(self):
+        original = {"protein": ["beef"]}
+        _normalize_enriched(original)
+        assert original["protein"] == ["beef"]
+
+
+class TestEnrichMenuNormalizesBeforeCache:
+    """Integration test: enrich_menu() applies _normalize_enriched before writing the cache."""
+
+    def test_normalized_values_written_to_cache(self, tmp_path):
+        menu_path = tmp_path / "menu.json"
+        cache_path = tmp_path / "cache.json"
+
+        menu_entry_text = "Grilled pork chop with potatoes"
+        menu_path.write_text(
+            json.dumps([{"date": "2026-06-01", "meal": menu_entry_text}]),
+            encoding="utf-8",
+        )
+
+        # Simulate Claude returning a scalar field (protein) as a list, and an array field intact.
+        mock_response = json.dumps(
+            {
+                "0": {
+                    "protein": ["pork"],
+                    "preparation": "grilled",
+                    "sides": ["potatoes", "kale"],
+                }
+            }
+        )
+
+        with patch("enrich_menu.call_claude", return_value=mock_response):
+            enrich_menu(menu_path, cache_path)
+
+        assert cache_path.exists(), "Cache file was not written"
+        cache = json.loads(cache_path.read_text(encoding="utf-8"))
+
+        # Locate the cache entry by hashing the menu text the same way the module does.
+        entry_hash = text_hash(menu_entry_text)
+        assert entry_hash in cache, (
+            f"Hash {entry_hash!r} not found in cache; keys: {list(cache)}"
+        )
+
+        entry = cache[entry_hash]
+        assert entry["protein"] == "pork", (
+            f"Expected protein coerced to 'pork' (string), got {entry['protein']!r}"
+        )
+        assert entry["preparation"] == "grilled", (
+            f"Expected preparation 'grilled' unchanged, got {entry['preparation']!r}"
+        )
+        assert entry["sides"] == ["potatoes", "kale"], (
+            f"Expected sides array preserved, got {entry['sides']!r}"
+        )


### PR DESCRIPTION
## Summary

Moves scalar-field normalization upstream into `enrich_menu.py` so bad shapes never accumulate in the enrichment cache. PR #66's defensive `_check` in `pairing.py` is retained as defense-in-depth.

## Changes

- **`scripts/enrich_menu.py`** — Add `SCALAR_FIELDS` frozenset and `_normalize_enriched()`: coerces list → first string element and non-string scalar → `str(val)`, with distinct stderr warnings per path. Wired into both the cache-hit path (self-heals existing poisoned entries) and the new-enrichment path (prevents bad shapes entering the cache). Prompt tightened to explicitly require scalar fields be single strings.
- **`tests/test_enrich_menu.py`** — 17 unit tests (`TestNormalizeEnriched`) + 1 integration test (`TestEnrichMenuNormalizesBeforeCache`). 311 total tests, all passing.
- **`pyrightconfig.json`** — Add `extraPaths: ["scripts"]` so Pylance resolves test-file imports without errors.

## Behavior

- Cache **self-heals** on the next pipeline run — no manual purge of `data/menu_enriched.json` required (though a purge is fine for certainty)
- Pipeline logs will show `WARNING: enrichment field '...' was a list` if Claude returns bad shapes, making future drift visible

## Testing

```
python3 -m pytest tests/ -v  # 311 passed
ruff check scripts/enrich_menu.py  # clean
```

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)